### PR TITLE
Fix dashboard link in sidebar

### DIFF
--- a/src/utils/sidebar-config.ts
+++ b/src/utils/sidebar-config.ts
@@ -27,7 +27,7 @@ export const sidebarConfig: SidebarSection[] = [
           height: 24.12,
         },
         label: "Dashboard",
-        href: "/",
+        href: "/dashboard",
       },
     ],
   },


### PR DESCRIPTION
The dashboard link in the sidebar was incorrectly pointing to `/` instead of `/dashboard`. This has been corrected in `src/utils/sidebar-config.ts`.