### PR TITLE
Fix: Handle auth state on page load

### DIFF
--- a/src/app/(features)/DashboardShell.tsx
+++ b/src/app/(features)/DashboardShell.tsx
@@ -5,9 +5,10 @@ import Nav from "@/components/Layout/Nav";
 import SearchInput from "@/components/general/SearchInput";
 import Image from "next/image";
 import { useState, useEffect, Suspense, useCallback } from "react";
-import { usePathname, useSearchParams } from "next/navigation";
-import { useDispatch } from "react-redux";
+import { usePathname, useSearchParams, useRouter } from "next/navigation";
+import { useDispatch, useSelector } from "react-redux";
 import { logout } from "@/store/auth/authSlice";
+import { RootState } from "@/store/store";
 
 function DashboardContent({
   children,
@@ -27,8 +28,20 @@ function DashboardContent({
   isMounted: boolean;
 }) {
   const dispatch = useDispatch();
+  const router = useRouter();
+  const { isAuthenticated, isAuthLoading } = useSelector((state: RootState) => state.auth);
   const [isProfileMenuOpen, setProfileMenuOpen] = useState(false);
   const pathname = usePathname();
+
+  useEffect(() => {
+    if (!isAuthLoading && !isAuthenticated) {
+      router.replace('/login');
+    }
+  }, [isAuthenticated, isAuthLoading, router]);
+
+  if (isAuthLoading) {
+    return <div>Loading...</div>; // Or a proper spinner component
+  }
   const searchParams = useSearchParams();
   const fullPath = `${pathname}${
     searchParams.toString() ? `?${searchParams.toString()}` : ""
@@ -134,6 +147,7 @@ function DashboardContent({
                       onClick={() => {
                         dispatch(logout());
                         setProfileMenuOpen(false);
+                        router.replace('/login');
                       }}
                       className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
                     >

--- a/src/store/StoreProvider.tsx
+++ b/src/store/StoreProvider.tsx
@@ -1,8 +1,30 @@
 "use client";
 
-import { Provider } from "react-redux";
+import { Provider, useDispatch } from "react-redux";
 import { store } from "./store";
+import { useEffect } from "react";
+import { authCheckCompleted } from "./auth/authSlice";
+
+// A component to handle the auth rehydration
+function AuthRehydrator({ children }: { children: React.ReactNode }) {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const token = document.cookie
+      .split('; ')
+      .find(row => row.startsWith('token='))
+      ?.split('=')[1];
+
+    dispatch(authCheckCompleted({ isAuthenticated: !!token }));
+  }, [dispatch]);
+
+  return <>{children}</>;
+}
 
 export function StoreProvider({ children }: { children: React.ReactNode }) {
-  return <Provider store={store}>{children}</Provider>;
+  return (
+    <Provider store={store}>
+      <AuthRehydrator>{children}</AuthRehydrator>
+    </Provider>
+  );
 }

--- a/src/store/auth/authSlice.ts
+++ b/src/store/auth/authSlice.ts
@@ -7,6 +7,7 @@ interface AuthState {
   loading: boolean;
   error: string | null;
   otpSent: boolean;
+  isAuthLoading: boolean;
 }
 
 const initialState: AuthState = {
@@ -16,6 +17,7 @@ const initialState: AuthState = {
   loading: false,
   error: null,
   otpSent: false,
+  isAuthLoading: true,
 };
 
 const authSlice = createSlice({
@@ -62,6 +64,10 @@ const authSlice = createSlice({
     },
     resetOtpSent(state) {
       state.otpSent = false;
+    },
+    authCheckCompleted(state, action: PayloadAction<{ isAuthenticated: boolean }>) {
+      state.isAuthenticated = action.payload.isAuthenticated;
+      state.isAuthLoading = false;
     }
   },
 });
@@ -74,7 +80,8 @@ export const {
     loginSuccess,
     loginFailure,
     logout,
-    resetOtpSent
+    resetOtpSent,
+    authCheckCompleted,
 } = authSlice.actions;
 
 export default authSlice.reducer;


### PR DESCRIPTION
Previously, refreshing the page would always redirect to login.

This commit introduces a robust client-side authentication check. An 'AuthRehydrator' component now runs on page load, checks for the auth token cookie, and updates the Redux store before any pages are rendered. This prevents wrongful redirection and ensures the UI correctly reflects the user's logged-in state on refresh.