### PR TITLE
Fix: Improve responsiveness of login and OTP pages

### DIFF
--- a/src/app/(auth)/login/otp/page.tsx
+++ b/src/app/(auth)/login/otp/page.tsx
@@ -32,7 +32,7 @@ export default function OtpPage() {
 
   return (
     <div className="m-auto px-2">
-      <div className="bg-white rounded-[28px] shadow-[0_0_4px_rgba(0,0,0,0.16)] px-[22px] py-[52px] w-[358px] max-w-full">
+      <div className="bg-white rounded-[28px] shadow-[0_0_4px_rgba(0,0,0,0.16)] px-[22px] py-[52px] w-full max-w-[358px]">
         <div className="mb-[47px]">
           <div className="flex flex-col items-center">
             <Image

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -30,7 +30,7 @@ export default function LoginPage() {
 
   return (
     <div className="m-auto px-2">
-      <div className="bg-white rounded-[28px] shadow-[0_0_4px_rgba(0,0,0,0.16)] px-[22px] py-[52px] w-[358px] max-w-full">
+      <div className="bg-white rounded-[28px] shadow-[0_0_4px_rgba(0,0,0,0.16)] px-[22px] py-[52px] w-full max-w-[358px]">
         <div className="mb-[47px]">
           <div className="flex flex-col items-center">
             <Image


### PR DESCRIPTION
The login and OTP pages had a fixed width, which caused horizontal overflow on smaller mobile devices.

This commit replaces the fixed-width class with a combination of 'w-full' and 'max-w-[358px]' to ensure the forms are responsive.