### PR TITLE
fix: make login and otp pages responsive

### DIFF
--- a/src/app/(auth)/login/otp/page.tsx
+++ b/src/app/(auth)/login/otp/page.tsx
@@ -32,7 +32,7 @@ export default function OtpPage() {
 
   return (
     <div className="m-auto px-2">
-      <div className="bg-white rounded-[28px] shadow-[0_0_4px_rgba(0,0,0,0.16)] px-[22px] py-[52px] w-full max-w-sm sm:max-w-lg">
+      <div className="bg-white rounded-[28px] shadow-[0_0_4px_rgba(0,0,0,0.16)] px-[22px] py-[52px] w-full max-w-md">
         <div className="mb-[47px]">
           <div className="flex flex-col items-center">
             <Image

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -30,7 +30,7 @@ export default function LoginPage() {
 
   return (
     <div className="m-auto px-2">
-      <div className="bg-white rounded-[28px] shadow-[0_0_4px_rgba(0,0,0,0.16)] px-[22px] py-[52px] w-full max-w-sm sm:max-w-lg">
+      <div className="bg-white rounded-[28px] shadow-[0_0_4px_rgba(0,0,0,0.16)] px-[22px] py-[52px] w-full max-w-md">
         <div className="mb-[47px]">
           <div className="flex flex-col items-center">
             <Image


### PR DESCRIPTION
- Replaced `max-w-sm sm:max-w-lg` with `max-w-md` in `login/page.tsx` and `login/otp/page.tsx` to ensure the layout is responsive on mobile devices.