### PR TITLE
refactor: Resolve no-explicit-any linting errors

### DIFF
--- a/src/services/authService.tsx
+++ b/src/services/authService.tsx
@@ -1,21 +1,24 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
+import { LoginPayload, SendOtpPayload } from '@/types/auth';
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
-export const loginData = async (endpoint: string, payload: any) => {
+export const loginData = async (endpoint: string, payload: LoginPayload) => {
   try {
     const response = await axios.post(`${BASE_URL}${endpoint}`, payload);
     return { result: response.data, msg: "success" };
-  } catch (error: any) {
-    return { msg: error.response?.data?.message || "Invalid Credentials" };
+  } catch (error) {
+    const axiosError = error as AxiosError<{ message: string }>;
+    return { msg: axiosError.response?.data?.message || "Invalid Credentials" };
   }
 };
 
-export const sendOtpData = async (endpoint: string, payload: any) => {
+export const sendOtpData = async (endpoint: string, payload: SendOtpPayload) => {
   try {
     const response = await axios.post(`${BASE_URL}${endpoint}`, payload);
     return { result: response.data, msg: "success" };
-  } catch (error: any) {
-    return { msg: error.response?.data?.message || "Failed to send OTP" };
+  } catch (error) {
+    const axiosError = error as AxiosError<{ message: string }>;
+    return { msg: axiosError.response?.data?.message || "Failed to send OTP" };
   }
 }

--- a/src/services/commonService.tsx
+++ b/src/services/commonService.tsx
@@ -1,3 +1,4 @@
+import { AxiosError } from 'axios';
 import axiosInstance from './apiHelper';
 
 // Example service functions
@@ -5,53 +6,57 @@ export const fetchData = async (endpoint: string) => {
   try {
     const response = await axiosInstance.get(`${endpoint}`);
     return response.data;
-  } catch (error: any) {
-    return { success: false, response: error.response.data.response };
+  } catch (error) {
+    const axiosError = error as AxiosError<{ response: string }>;
+    return { success: false, response: axiosError.response?.data.response };
   }
 };
 
-export const postData = async (endpoint: string, data: any) => {
+export const postData = async <T>(endpoint: string, data: T) => {
   try {
     const response = await axiosInstance.post(`${endpoint}`, data);
     console.log('response=>', response);
 
     return response.data;
-  } catch (error: any) {
-    console.log("error=>", error);
+  } catch (error) {
+    const axiosError = error as AxiosError<{ response: string, message: string }>;
+    console.log("error=>", axiosError);
 
     let message = "Something went wrong";
 
-    if (error.response) {
+    if (axiosError.response) {
       // Server responded (like 413, 500, etc.)
       message =
-        error.response.data?.response ||     // your backend JSON error (if any)
-        error.response.data?.message ||      // common API error format
-        error.response.statusText ||         // e.g. "Request Entity Too Large"
-        `Error ${error.response.status}`;    // fallback (e.g. Error 413)
-    } else if (error.request) {
+        axiosError.response.data?.response ||     // your backend JSON error (if any)
+        axiosError.response.data?.message ||      // common API error format
+        axiosError.response.statusText ||         // e.g. "Request Entity Too Large"
+        `Error ${axiosError.response.status}`;    // fallback (e.g. Error 413)
+    } else if (axiosError.request) {
       message = "No response from server (possible CORS or network issue)";
     } else {
-      message = error.message;
+      message = axiosError.message;
     }
 
     return { success: false, response: message };
   }
 };
 
-export const putData = async (endpoint: string, data: any) => {
+export const putData = async <T>(endpoint: string, data: T) => {
   try {
     const response = await axiosInstance.put(`${endpoint}`, data);
     return response.data;
-  } catch (error: any) {
-    return { success: false, response: error.response.data.response };
+  } catch (error) {
+    const axiosError = error as AxiosError<{ response: string }>;
+    return { success: false, response: axiosError.response?.data.response };
   }
 };
 export const deleteData = async (endpoint: string) => {
   try {
     const response = await axiosInstance.delete(`${endpoint}`);
     return response.data;
-  } catch (error: any) {
-    return { success: false, response: error.response.data.response };
+  } catch (error) {
+    const axiosError = error as AxiosError<{ response: string }>;
+    return { success: false, response: axiosError.response?.data.response };
   }
 };
 

--- a/src/store/auth/authSaga.ts
+++ b/src/store/auth/authSaga.ts
@@ -9,6 +9,7 @@ import {
   loginFailure
 } from './authSlice';
 import { setAuthToken } from '@/services/apiHelper';
+import { AuthResponse } from '@/types/auth';
 
 function* handleSendOtp(action: ReturnType<typeof sendOtpRequest>) {
   const { phoneNumber } = action.payload;
@@ -19,23 +20,25 @@ function* handleSendOtp(action: ReturnType<typeof sendOtpRequest>) {
     } else {
       yield put(sendOtpFailure(response.msg || 'Failed to send OTP'));
     }
-  } catch (error: any) {
-    yield put(sendOtpFailure(error.message || 'An unknown error occurred'));
+  } catch (error) {
+    const err = error as Error;
+    yield put(sendOtpFailure(err.message || 'An unknown error occurred'));
   }
 }
 
 function* handleLogin(action: ReturnType<typeof loginRequest>) {
     const { phoneNumber, otp } = action.payload;
   try {
-    const response: { msg: string, result?: { token: string, user: any } } = yield call(loginData, '/api/verify-otp', { phone: phoneNumber, otp });
+    const response: AuthResponse = yield call(loginData, '/api/verify-otp', { phone: phoneNumber, otp });
     if (response.msg === 'success' && response.result?.token) {
       setAuthToken(response.result.token);
       yield put(loginSuccess(response.result.user));
     } else {
       yield put(loginFailure(response.msg || 'Login failed'));
     }
-  } catch (error: any) {
-    yield put(loginFailure(error.message || 'An unknown error occurred'));
+  } catch (error) {
+    const err = error as Error;
+    yield put(loginFailure(err.message || 'An unknown error occurred'));
   }
 }
 

--- a/src/store/auth/authSlice.ts
+++ b/src/store/auth/authSlice.ts
@@ -1,8 +1,9 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { Account } from '@/types/entities';
 
 interface AuthState {
   isAuthenticated: boolean;
-  user: any; // Replace 'any' with a proper user type
+  user: Account | null;
   phoneNumber: string | null;
   loading: boolean;
   error: string | null;
@@ -43,7 +44,7 @@ const authSlice = createSlice({
         state.loading = true;
         state.error = null;
     },
-    loginSuccess(state, action: PayloadAction<any>) {
+    loginSuccess(state, action: PayloadAction<Account>) {
       state.loading = false;
       state.isAuthenticated = true;
       state.user = action.payload;

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,18 @@
+import { Account } from "./entities";
+
+export interface LoginPayload {
+    phone: string;
+    otp: string;
+  }
+
+  export interface SendOtpPayload {
+    phone: string;
+  }
+
+  export interface AuthResponse {
+    msg: string;
+    result?: {
+      token: string;
+      user: Account;
+    };
+  }


### PR DESCRIPTION
Replaced all instances of `any` with specific TypeScript types and interfaces to improve type safety and resolve linting errors.

- Created `src/types/auth.ts` to define `LoginPayload`, `SendOtpPayload`, and `AuthResponse` interfaces.
- Updated `authService.tsx`, `authSaga.ts`, and `authSlice.ts` to use these new types.
- Used generics for `postData` and `putData` in `commonService.tsx` to maintain type safety for generic API calls.
- Replaced `any` for error handling with `AxiosError` or `Error` types.