### PR TITLE
fix: Resolve all TypeScript linting and type errors

### DIFF
--- a/src/services/apiHelper.tsx
+++ b/src/services/apiHelper.tsx
@@ -23,12 +23,9 @@ axiosInstance.interceptors.request.use((config) => {
         const token = JSON.parse(detoken);
 
         if (token) {
-            const headers = {
-              Authorization: `Bearer ${token}`,
-              'Accept': 'application/json',
-              'Content-Type': 'application/json',
-            };
-            config.headers = { ...config.headers, ...headers };
+            config.headers.set('Authorization', `Bearer ${token}`);
+            config.headers.set('Accept', 'application/json');
+            config.headers.set('Content-Type', 'application/json');
         }
       } catch (e) {
         console.error("Failed to decrypt token", e)


### PR DESCRIPTION
This commit resolves all reported TypeScript linting and type errors, including `no-explicit-any`, `no-unused-vars`, parsing errors, and a type mismatch with Axios headers.

- Replaced all instances of `any` with specific TypeScript types and interfaces to improve type safety.
- Created `src/types/auth.ts` to define authentication-related interfaces.
- Used generics for `postData` and `putData` in `commonService.tsx`.
- Replaced `any` for error handling with `AxiosError` or `Error` types.
- Fixed a parsing error in `commonService.tsx` by adding a trailing comma to the generic type parameter in arrow functions.
- Resolved `no-unused-vars` errors in `authSlice.ts` by prefixing the unused `action` parameter with an underscore.
- Corrected a type error in `apiHelper.tsx` by using the `set` method to modify `AxiosRequestHeaders` instead of object spreading.