### PR TITLE
fix: Resolve all TypeScript linting and type errors

### DIFF
--- a/src/store/auth/authSlice.ts
+++ b/src/store/auth/authSlice.ts
@@ -25,6 +25,7 @@ const authSlice = createSlice({
   name: 'auth',
   initialState,
   reducers: {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     sendOtpRequest(state, _action: PayloadAction<{ phoneNumber: string }>) {
       state.loading = true;
       state.error = null;
@@ -40,6 +41,7 @@ const authSlice = createSlice({
       state.error = action.payload;
       state.otpSent = false;
     },
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     loginRequest(state, _action: PayloadAction<{ phoneNumber: string, otp: string }>) {
         state.loading = true;
         state.error = null;


### PR DESCRIPTION
This commit resolves all reported TypeScript linting and type errors, including `no-explicit-any`, `no-unused-vars`, parsing errors, and a type mismatch with Axios headers.

- Replaced all instances of `any` with specific TypeScript types and interfaces to improve type safety.
- Created `src/types/auth.ts` to define authentication-related interfaces.
- Used generics for `postData` and `putData` in `commonService.tsx`.
- Replaced `any` for error handling with `AxiosError` or `Error` types.
- Fixed a parsing error in `commonService.tsx` by adding a trailing comma to the generic type parameter in arrow functions.
- Resolved `no-unused-vars` errors in `authSlice.ts` by disabling the ESLint rule for intentionally unused parameters.
- Corrected a type error in `apiHelper.tsx` by using the `set` method to modify `AxiosRequestHeaders` instead of object spreading.