### PR TITLE
fix: Regenerate captcha on failure and ensure unique image

### DIFF
--- a/src/components/general/SlideCaptcha.tsx
+++ b/src/components/general/SlideCaptcha.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, MouseEvent, TouchEvent, useEffect } from 'react';
+import { useState, useRef, MouseEvent, TouchEvent, useEffect, useCallback } from 'react';
 import Image from 'next/image';
 
 interface SlideCaptchaProps {
@@ -16,22 +16,29 @@ export default function SlideCaptcha({ onSuccess }: SlideCaptchaProps) {
   const [sliderValue, setSliderValue] = useState(0);
   const [puzzlePosition, setPuzzlePosition] = useState({ x: 0, y: 0 });
   const [targetPosition, setTargetPosition] = useState({ x: 0, y: 0 });
+  const [imageUrl, setImageUrl] = useState('');
 
   const sliderRef = useRef<HTMLDivElement>(null);
   const handleRef = useRef<HTMLDivElement>(null);
   const imageRef = useRef<HTMLDivElement>(null);
 
-  const imageUrl = "https://picsum.photos/300/150";
+  const generatePuzzle = useCallback(() => {
+    const random = Date.now();
+    setImageUrl(`https://picsum.photos/300/150?random=${random}`);
 
-  useEffect(() => {
-    // Randomly determine the target position for the puzzle piece
     const imageWidth = 300;
     const imageHeight = 150;
     const targetX = Math.floor(Math.random() * (imageWidth - PUZZLE_WIDTH - 100)) + 100; // Avoid edges
     const targetY = Math.floor(Math.random() * (imageHeight - PUZZLE_HEIGHT));
+
     setTargetPosition({ x: targetX, y: targetY });
     setPuzzlePosition({ x: 0, y: targetY });
+    setSliderValue(0);
   }, []);
+
+  useEffect(() => {
+    generatePuzzle();
+  }, [generatePuzzle]);
 
   const handleDragStart = () => {
     setIsDragging(true);
@@ -45,8 +52,7 @@ export default function SlideCaptcha({ onSuccess }: SlideCaptchaProps) {
       if (isCorrect) {
         onSuccess();
       } else {
-        setSliderValue(0);
-        setPuzzlePosition({ x: 0, y: targetPosition.y });
+        generatePuzzle();
       }
       setIsDragging(false);
     }
@@ -76,31 +82,33 @@ export default function SlideCaptcha({ onSuccess }: SlideCaptchaProps) {
 
   return (
     <div className="flex flex-col items-center gap-4">
-        <div ref={imageRef} className="relative w-[300px] h-[150px]">
-            <Image src={imageUrl} alt="Captcha" width={300} height={150} />
-            <div
-                className="absolute bg-white border-2 border-dashed border-gray-500"
-                style={{
-                    width: `${PUZZLE_WIDTH}px`,
-                    height: `${PUZZLE_HEIGHT}px`,
-                    top: `${targetPosition.y}px`,
-                    left: `${targetPosition.x}px`,
-                    backgroundColor: 'rgba(255, 255, 255, 0.5)',
-                }}
-            />
-            <div
-                className="absolute"
-                style={{
-                    width: `${PUZZLE_WIDTH}px`,
-                    height: `${PUZZLE_HEIGHT}px`,
-                    top: `${puzzlePosition.y}px`,
-                    left: `${puzzlePosition.x}px`,
-                    backgroundImage: `url(${imageUrl})`,
-                    backgroundPosition: `-${targetPosition.x}px -${targetPosition.y}px`,
-                    boxShadow: '0 0 10px rgba(0,0,0,0.5)',
-                }}
-            />
-        </div>
+        {imageUrl && (
+            <div ref={imageRef} className="relative w-[300px] h-[150px]">
+                <Image src={imageUrl} alt="Captcha" width={300} height={150} key={imageUrl} />
+                <div
+                    className="absolute bg-white border-2 border-dashed border-gray-500"
+                    style={{
+                        width: `${PUZZLE_WIDTH}px`,
+                        height: `${PUZZLE_HEIGHT}px`,
+                        top: `${targetPosition.y}px`,
+                        left: `${targetPosition.x}px`,
+                        backgroundColor: 'rgba(255, 255, 255, 0.5)',
+                    }}
+                />
+                <div
+                    className="absolute"
+                    style={{
+                        width: `${PUZZLE_WIDTH}px`,
+                        height: `${PUZZLE_HEIGHT}px`,
+                        top: `${puzzlePosition.y}px`,
+                        left: `${puzzlePosition.x}px`,
+                        backgroundImage: `url(${imageUrl})`,
+                        backgroundPosition: `-${targetPosition.x}px -${targetPosition.y}px`,
+                        boxShadow: '0 0 10px rgba(0,0,0,0.5)',
+                    }}
+                />
+            </div>
+        )}
 
       <div
         className="w-full bg-gray-200 rounded-full h-12 flex items-center relative select-none mt-2"


### PR DESCRIPTION
This commit refactors the `SlideCaptcha` component to address two issues:
1. The captcha image was not changing because of browser caching. This is fixed by appending a unique timestamp to the image URL to ensure a new image is fetched every time.
2. The captcha puzzle was not changing after a failed attempt. This is fixed by introducing a `generatePuzzle` function that creates a new puzzle with a new image and a new target position. This function is called on initial load and on every failed attempt.

These changes ensure that the user is presented with a new, unique captcha challenge every time, improving both user experience and security.