### PR TITLE
fix: Resolve 'Account not found' error on create page

### DIFF
--- a/src/app/(features)/businesses/accounts/[accountId]/page.tsx
+++ b/src/app/(features)/businesses/accounts/[accountId]/page.tsx
@@ -41,8 +41,8 @@ export default function AccountPage() {
     }
   }, [searchParams]);
 
-  // Show loading or not found state
-  if (!account) {
+  // Show loading or not found state for edit mode
+  if (!account && accountId !== "create") {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <div className="text-center">
@@ -60,11 +60,13 @@ export default function AccountPage() {
   return (
     <div>
       <div>
-        <AccountHeader
-          account={account}
-          activeTab={activeTab}
-          onTabChange={handleTabChange}
-        />
+        {account && (
+          <AccountHeader
+            account={account}
+            activeTab={activeTab}
+            onTabChange={handleTabChange}
+          />
+        )}
         <AccountTabContent activeTab={activeTab} accountId={accountId} />
       </div>
     </div>


### PR DESCRIPTION
This commit fixes a bug where navigating to `/businesses/accounts/create` would result in an "Account not found" error.

The page component was checking for a valid account from the database before rendering the page content. This check now correctly bypasses the lookup when the `accountId` parameter is 'create'.

Additionally, the `AccountHeader` component is now only rendered when an account is present (i.e., in edit mode), preventing potential errors and cleaning up the UI for the create account flow.