### PR TITLE
feat: Update account form with dynamic brand search and UI changes

### DIFF
--- a/src/services/commonService.tsx
+++ b/src/services/commonService.tsx
@@ -65,4 +65,8 @@ export const createAccount = async (accountData: CreateAccountPayload) => {
   return postData('https://dev-partners.alist.ae/api/api/add/account', accountData);
 };
 
+export const searchVenues = async (key: string) => {
+  return fetchData(`/api/list/venues?search=${key}`);
+};
+
 // You can add more functions as needed

--- a/src/store/account/accountSlice.ts
+++ b/src/store/account/accountSlice.ts
@@ -5,14 +5,16 @@ interface AccountState {
   loading: boolean;
   error: string | null;
   account: Account | null;
-  brands: Brand[];
+  searchedBrands: Brand[];
+  searchedBrandsLoading: boolean;
 }
 
 const initialState: AccountState = {
   loading: false,
   error: null,
   account: null,
-  brands: [],
+  searchedBrands: [],
+  searchedBrandsLoading: false,
 };
 
 const accountSlice = createSlice({
@@ -31,8 +33,16 @@ const accountSlice = createSlice({
       state.loading = false;
       state.error = action.payload;
     },
-    fetchBrandsSuccess(state, action: PayloadAction<Brand[]>) {
-      state.brands = action.payload;
+    searchBrandsRequest(state, action: PayloadAction<string>) {
+      state.searchedBrandsLoading = true;
+    },
+    searchBrandsSuccess(state, action: PayloadAction<Brand[]>) {
+      state.searchedBrandsLoading = false;
+      state.searchedBrands = action.payload;
+    },
+    searchBrandsFailure(state, action: PayloadAction<string>) {
+      state.searchedBrandsLoading = false;
+      // You might want to handle the error state as well
     },
   },
 });
@@ -41,7 +51,9 @@ export const {
   createAccountStart,
   createAccountSuccess,
   createAccountFailure,
-  fetchBrandsSuccess,
+  searchBrandsRequest,
+  searchBrandsSuccess,
+  searchBrandsFailure,
 } = accountSlice.actions;
 
 export default accountSlice.reducer;


### PR DESCRIPTION
This commit incorporates user feedback to improve the create/edit account form.

- **Affiliation Dropdown:** The "Account Type" dropdown has been relabeled to "Affiliation" and its options have been updated to 'individual', 'agency', and 'enterprise'. The underlying API payload key remains `account_type`.
- **Dynamic Brand Search:** The "Brands" dropdown functionality has been completely refactored. It now dynamically fetches data from the `/api/list/venues` endpoint as the user types into a search field. This is handled via a debounced Redux saga to ensure efficient API usage.
- **UI Label Change:** The "Venues" label has been changed to "Brands" for clarity.