### PR TITLE
fix: Handle brand search API response correctly

### DIFF
--- a/src/store/account/accountSaga.ts
+++ b/src/store/account/accountSaga.ts
@@ -20,12 +20,54 @@ function* handleCreateAccount(action: ReturnType<typeof createAccountStart>) {
   }
 }
 
+// Define a type for the raw venue object from the API
+type ApiVenue = {
+  id: number;
+  venue_title: string;
+  // ... other properties from the API if any
+};
+
 function* handleSearchBrands(action: ReturnType<typeof searchBrandsRequest>) {
   yield delay(500); // Debounce API call
 
   try {
-    const brands: Brand[] = yield call(searchVenues, action.payload);
-    yield put(searchBrandsSuccess(brands || [])); // Ensure payload is not undefined
+    // Type the response according to the API documentation
+    const response: { venues: ApiVenue[] } = yield call(searchVenues, action.payload);
+
+    // Check if the response and the venues property exist
+    if (response && Array.isArray(response.venues)) {
+      // Map the API response to the Brand type used by the frontend
+      const mappedBrands: Brand[] = response.venues.map(venue => ({
+        brandId: venue.id.toString(),
+        name: venue.venue_title,
+        // Provide sensible defaults for other required Brand properties
+        accountId: '',
+        logo: '',
+        phoneNumber: '',
+        emailAddress: '',
+        industry: '',
+        companyName: '',
+        businessLocation: '',
+        tradeLicenseCopy: '',
+        vatCertificate: '',
+        instagramHandle: '',
+        websiteUrl: '',
+        associateFirstName: '',
+        associateLastName: '',
+        associateEmail: '',
+        associatePhone: '',
+        associateInitials: '',
+        associateBackground: '',
+        offersCount: 0,
+        campaignsCount: 0,
+        profileCompletion: 0,
+      }));
+      yield put(searchBrandsSuccess(mappedBrands));
+    } else {
+      // If the structure is not what we expect, dispatch success with an empty array
+      yield put(searchBrandsSuccess([]));
+      console.error("API response for brand search is not in the expected format:", response);
+    }
   } catch (error) {
     const err = error as Error;
     yield put(searchBrandsFailure(err.message || 'An unknown error occurred'));


### PR DESCRIPTION
This commit fixes a runtime error (`.map is not a function`) that occurred during the brand/venue search.

The root cause was a mismatch between the expected API response format and the actual format. The saga now correctly:
1.  Expects an object with a `venues` key instead of a direct array.
2.  Extracts the `venues` array from the response.
3.  Maps the venue data (e.g., `{id, venue_title}`) to the `Brand` type expected by the frontend components (e.g., `{brandId, name}`).

This ensures the application no longer crashes and that the search results are displayed correctly.