### PR TITLE
feat: Make account page editable for create/edit operations

### DIFF
--- a/src/app/(features)/businesses/accounts/[accountId]/page.tsx
+++ b/src/app/(features)/businesses/accounts/[accountId]/page.tsx
@@ -5,35 +5,50 @@ import { useRouter, useSearchParams, useParams } from "next/navigation";
 import AccountHeader from "@/components/features/accounts/AccountHeader";
 import AccountTabContent from "@/components/features/accounts/AccountTabContent";
 import { AccountsData } from "@/data/AccountsData";
-import { Account } from "@/types/entities";
+import { Account, AccountType } from "@/types/entities";
 
 export default function AccountPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const params = useParams();
   const accountId = params.accountId as string;
+  const isCreateMode = accountId === "create";
 
   const [activeTab, setActiveTab] = useState(
     searchParams.get("tab") || "Details"
   );
-  const [account, setAccount] = useState<Account | null>(null);
+  const [account, setAccount] = useState<Partial<Account> | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
-  // Fetch account data based on accountId
   useEffect(() => {
-    const foundAccount = AccountsData.find(
-      (acc) => acc.accountId === accountId
-    );
-    setAccount(foundAccount || null);
-  }, [accountId]);
+    if (isCreateMode) {
+      setAccount({
+        firstName: "",
+        lastName: "",
+        emailAddress: "",
+        phoneNumber: "",
+        affiliation: "",
+        accountType: AccountType.INDIVIDUAL,
+      });
+      setIsLoading(false);
+    } else {
+      const foundAccount = AccountsData.find(
+        (acc) => acc.accountId === accountId
+      );
+      setAccount(foundAccount || null);
+      setIsLoading(false);
+    }
+  }, [accountId, isCreateMode]);
 
   const handleTabChange = (tab: string) => {
     setActiveTab(tab);
-    const params = new URLSearchParams(searchParams.toString());
-    params.set("tab", tab);
-    router.push(`?${params.toString()}`);
+    if (!isCreateMode) {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("tab", tab);
+      router.push(`?${params.toString()}`);
+    }
   };
 
-  // Update active tab when URL changes
   useEffect(() => {
     const tab = searchParams.get("tab");
     if (tab) {
@@ -41,7 +56,55 @@ export default function AccountPage() {
     }
   }, [searchParams]);
 
-  // Show loading or not found state
+  const handleSave = (formData: Partial<Account>) => {
+    if (isCreateMode) {
+      const newAccount: Account = {
+        ...formData,
+        accountId: new Date().getTime().toString(),
+        avatarInitials: `${formData.firstName?.[0] || ""}${
+          formData.lastName?.[0] || ""
+        }`.toUpperCase(),
+        avatarBackground:
+          "#" +
+          Math.floor(Math.random() * 16777215)
+            .toString(16)
+            .padStart(6, "0"),
+        signUpDate: new Date(),
+        subscriptionCount: 0,
+        brandsCount: 0,
+        campaignsCount: 0,
+      } as Account;
+      AccountsData.push(newAccount);
+      alert("Account created successfully!");
+      router.push(`/businesses/accounts/${newAccount.accountId}`);
+    } else {
+      const accountIndex = AccountsData.findIndex(
+        (acc) => acc.accountId === accountId
+      );
+      if (accountIndex !== -1) {
+        const updatedAccount = {
+          ...AccountsData[accountIndex],
+          ...formData,
+          avatarInitials: `${formData.firstName?.[0] || ""}${
+            formData.lastName?.[0] || ""
+          }`.toUpperCase(),
+        };
+        AccountsData[accountIndex] = updatedAccount;
+        setAccount(updatedAccount);
+        alert("Account updated successfully!");
+        router.refresh();
+      }
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <p>Loading...</p>
+      </div>
+    );
+  }
+
   if (!account) {
     return (
       <div className="flex items-center justify-center min-h-screen">
@@ -64,8 +127,13 @@ export default function AccountPage() {
           account={account}
           activeTab={activeTab}
           onTabChange={handleTabChange}
+          isCreateMode={isCreateMode}
         />
-        <AccountTabContent activeTab={activeTab} accountId={accountId} />
+        <AccountTabContent
+          activeTab={activeTab}
+          account={account}
+          onSave={handleSave}
+        />
       </div>
     </div>
   );

--- a/src/components/features/accounts/AccountDetails.tsx
+++ b/src/components/features/accounts/AccountDetails.tsx
@@ -1,42 +1,59 @@
 "use client";
 
-import Image from "next/image";
-import { useEffect, useState } from "react";
-import { AccountsData } from "@/data/AccountsData";
-import { Account } from "@/types/entities";
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Account, AccountType } from "@/types/entities";
 
-export default function AccountDetails({
-  accountId = "0",
-}: {
-  accountId?: string;
-}) {
-  const [account, setAccount] = useState<Account | null>(null);
+interface AccountDetailsProps {
+  account: Partial<Account> | null;
+  onSave: (account: Partial<Account>) => void;
+}
 
-  // Fetch account data based on accountId
+export default function AccountDetails({ account, onSave }: AccountDetailsProps) {
+  const [formData, setFormData] = useState<Partial<Account>>(
+    account || {
+      firstName: "",
+      lastName: "",
+      emailAddress: "",
+      phoneNumber: "",
+      affiliation: "",
+      accountType: AccountType.INDIVIDUAL,
+    }
+  );
+  const router = useRouter();
+
   useEffect(() => {
-    const foundAccount = AccountsData.find(
-      (acc) => acc.accountId === accountId
-    );
-    setAccount(foundAccount || null);
-  }, [accountId]);
+    if (account) {
+      setFormData(account);
+    }
+  }, [account]);
 
-  if (!account) {
-    return (
-      <div className="flex items-center justify-center min-h-[200px]">
-        <p className="text-gray-500">Account not found.</p>
-      </div>
-    );
-  }
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!formData.firstName || !formData.emailAddress) {
+      alert("First name and email are required.");
+      return;
+    }
+    onSave(formData);
+  };
+
   const InputField = ({
     label,
     value,
-    showIcon = false,
     name,
+    type = "text",
   }: {
     label: string;
     value: string;
-    showIcon?: boolean;
     name: string;
+    type?: string;
   }) => (
     <div className="mb-5 md:mb-7">
       <label htmlFor={name} className="block text-[#4F4F4F] mb-2.5">
@@ -44,66 +61,91 @@ export default function AccountDetails({
       </label>
       <div className="relative">
         <input
-          type="text"
+          type={type}
           id={name}
           name={name}
           value={value}
-          readOnly
+          onChange={handleChange}
           className="w-full bg-[#F8F8F8] md:bg-[#F3F3F3] border md:border-0 border-[#E4E4E4] rounded-[11px] px-4 py-3 text-[#6E6E6E] placeholder:text-[#6E6E6E] outline-none"
         />
-        {showIcon && (
-          <div className="absolute right-3 top-1/2 -translate-y-1/2">
-            <Image
-              src="/icons/edit-icon.svg"
-              alt="copy"
-              width={12.14}
-              height={12.13}
-              className="opacity-50 hover:opacity-100 transition-opacity"
-            />
-          </div>
-        )}
       </div>
     </div>
   );
 
   return (
-    <div className="text-[15px] pt-10 md:pt-11">
+    <form onSubmit={handleSubmit} className="text-[15px] pt-10 md:pt-11">
       <div className="max-w-[559px] mx-auto px-[15px]">
         <div className="bg-white rounded-[13px] md:px-10 md:pt-8 md:pb-3">
           <div className="grid grid-cols-2 gap-5 mb-1">
             <InputField
               label="First name"
-              value={account.firstName}
+              value={formData.firstName || ""}
               name="firstName"
             />
             <InputField
               label="Last name"
-              value={account.lastName}
+              value={formData.lastName || ""}
               name="lastName"
             />
           </div>
           <InputField
             label="Email"
-            value={account.emailAddress}
-            showIcon
-            name="email"
+            value={formData.emailAddress || ""}
+            name="emailAddress"
+            type="email"
           />
           <InputField
             label="Phone"
-            value={account.phoneNumber}
-            showIcon
-            name="phone"
+            value={formData.phoneNumber || ""}
+            name="phoneNumber"
+            type="tel"
           />
           <InputField
             label="Affiliation"
-            value={account.affiliation}
+            value={formData.affiliation || ""}
             name="affiliation"
           />
+          <div className="mb-5 md:mb-7">
+            <label
+              htmlFor="accountType"
+              className="block text-[#4F4F4F] mb-2.5"
+            >
+              Account Type
+            </label>
+            <select
+              id="accountType"
+              name="accountType"
+              value={formData.accountType}
+              onChange={handleChange}
+              className="w-full bg-[#F8F8F8] md:bg-[#F3F3F3] border md:border-0 border-[#E4E4E4] rounded-[11px] px-4 py-3 text-[#6E6E6E] outline-none"
+            >
+              <option value={AccountType.INDIVIDUAL}>Individual</option>
+              <option value={AccountType.AGENCY}>Agency</option>
+            </select>
+          </div>
+          <div className="flex justify-end gap-4 mt-6">
+            <button
+              type="button"
+              onClick={() => router.back()}
+              className="px-6 py-2 text-sm font-semibold text-gray-700 bg-gray-200 rounded-lg hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="px-6 py-2 text-sm font-semibold text-white bg-blue-600 rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              Save Account
+            </button>
+          </div>
         </div>
-        <p className="text-sm text-[#4F4F4F] mt-4">
-          Registration date: {account.signUpDate.toLocaleDateString()}
-        </p>
+        {account?.signUpDate && (
+          <p className="text-sm text-[#4F4F4F] mt-4">
+            Registration date:{" "}
+            {new Date(account.signUpDate).toLocaleDateString()}
+          </p>
+        )}
       </div>
-    </div>
+    </form>
   );
 }

--- a/src/components/features/accounts/AccountHeader.tsx
+++ b/src/components/features/accounts/AccountHeader.tsx
@@ -6,18 +6,20 @@ const menuIcon = "/icons/common/menu-dots.svg";
 import { Account } from "@/types/entities";
 
 interface AccountHeaderProps {
-  account: Account;
-  tabs?: string[];
+  account?: Partial<Account>;
   activeTab?: string;
   onTabChange?: (tab: string) => void;
+  isCreateMode?: boolean;
 }
 
 export default function AccountHeader({
   account,
-  tabs = ["Details", "Brands", "Plans"],
   activeTab,
   onTabChange,
+  isCreateMode = false,
 }: AccountHeaderProps) {
+  const displayTabs = isCreateMode ? ["Details"] : ["Details", "Brands", "Plans"];
+
   return (
     <div className="w-full bg-white px-6 border-b border-[#E2E2E2] relative">
       <div
@@ -28,25 +30,35 @@ export default function AccountHeader({
         {/* Header */}
         <div>
           <div className="flex items-center md:gap-10 gap-6 ">
-            <div
-              className="flex items-center justify-center w-[74px] h-[74px] min-w-[45px] min-h-[45px] md:w-27 md:h-27 rounded-full border-5 border-[#EEEEEE] text-white text-[24px] md:text-[40px] font-semibold shrink-0"
-              style={{ backgroundColor: account.avatarBackground }}
-            >
-              {account.avatarInitials}
-            </div>
-            <div>
-              <h1 className="text-[18px] md:text-[25px] font-semibold ">
-                {`${account.firstName} ${account.lastName}`}
-              </h1>
-              <p className="text-[15px] md:text-[18px] font-medium ">
-                {account.affiliation}
-              </p>
-            </div>
+            {isCreateMode ? (
+              <div>
+                <h1 className="text-[18px] md:text-[25px] font-semibold ">
+                  Create New Account
+                </h1>
+              </div>
+            ) : (
+              <>
+                <div
+                  className="flex items-center justify-center w-[74px] h-[74px] min-w-[45px] min-h-[45px] md:w-27 md:h-27 rounded-full border-5 border-[#EEEEEE] text-white text-[24px] md:text-[40px] font-semibold shrink-0"
+                  style={{ backgroundColor: account?.avatarBackground }}
+                >
+                  {account?.avatarInitials}
+                </div>
+                <div>
+                  <h1 className="text-[18px] md:text-[25px] font-semibold ">
+                    {`${account?.firstName || ""} ${account?.lastName || ""}`}
+                  </h1>
+                  <p className="text-[15px] md:text-[18px] font-medium ">
+                    {account?.affiliation}
+                  </p>
+                </div>
+              </>
+            )}
           </div>
 
           {/* Tabs */}
           <UnifiedTabs
-            tabs={tabs}
+            tabs={displayTabs}
             activeTab={activeTab}
             onTabChange={onTabChange}
           />

--- a/src/components/features/accounts/AccountTabContent.tsx
+++ b/src/components/features/accounts/AccountTabContent.tsx
@@ -2,29 +2,32 @@ import AccountDetails from "@/components/features/accounts/AccountDetails";
 import AccountBrands from "./AccountBrands";
 import AccountPlans from "./AccountPlans";
 import { TabContentProps } from "@/components/general/UnifiedTabs";
+import { Account } from "@/types/entities";
 
 interface AccountTabContentProps extends TabContentProps {
-  accountId?: string;
+  account: Partial<Account> | null;
+  onSave: (account: Partial<Account>) => void;
 }
 
 export default function AccountTabContent({
   activeTab,
-  accountId,
+  account,
+  onSave,
 }: AccountTabContentProps) {
   const renderContent = () => {
     switch (activeTab) {
       case "Details":
-        return <AccountDetails accountId={accountId} />;
+        return <AccountDetails account={account} onSave={onSave} />;
       case "Brands":
         return (
           <div className="max-w-[1428px] mx-auto flex justify-between pt-10 text-[#4F4F4F]">
-            <AccountBrands accountId={accountId} />
+            <AccountBrands accountId={account?.accountId} />
           </div>
         );
       case "Plans":
         return (
           <div className="px-4 pt-[45px]">
-            <AccountPlans accountId={accountId} />
+            <AccountPlans accountId={account?.accountId} />
           </div>
         );
       default:


### PR DESCRIPTION
Refactors the account details page at `.../[accountId]/page.tsx` to support both creating new accounts and editing existing ones within a single page component, following user specifications.

- The page now handles the URL `.../accounts/create` to render a form for new account creation.
- The form logic and UI are embedded directly within the `AccountDetails.tsx` component, avoiding the creation of new component files as requested.
- `AccountHeader.tsx` is updated to conditionally display a "Create New Account" title and a simplified tab layout for the create mode.
- The save handler in the main page component correctly creates or updates accounts in the mock data source.