### PR TITLE
fix: Clear search input in brand combobox after selection

### DIFF
--- a/src/components/features/accounts/BrandSearchCombobox.tsx
+++ b/src/components/features/accounts/BrandSearchCombobox.tsx
@@ -78,6 +78,7 @@ export default function BrandSearchCombobox({
           <Combobox.Input
             className="w-full bg-[#F8F8F8] md:bg-[#F3F3F3] border md:border-0 border-[#E4E4E4] rounded-[11px] px-4 py-3 text-[#6E6E6E] placeholder:text-[#6E6E6E] outline-none"
             placeholder="Search for brands..."
+            value={query}
             onChange={(event) => setQuery(event.target.value)}
             autoComplete="off"
           />


### PR DESCRIPTION
This commit fixes a bug in the `BrandSearchCombobox` where the search input text was not being cleared after a user selected a brand.

The `Combobox.Input` component is now a fully controlled component by binding its `value` to the `query` state. This ensures that when the `query` state is reset after a selection, the input field is visually cleared, allowing the user to immediately search for another brand.