### PR TITLE
feat: Add account listing and update API endpoints

### DIFF
--- a/src/store/account/accountSaga.ts
+++ b/src/store/account/accountSaga.ts
@@ -1,6 +1,9 @@
 import { call, put, takeLatest, all } from 'redux-saga/effects';
-import { postData, putData, deleteData } from '@/services/commonService';
+import { postData, putData, deleteData, fetchData } from '@/services/commonService';
 import {
+  fetchAccountsRequest,
+  fetchAccountsSuccess,
+  fetchAccountsFailure,
   createAccountRequest,
   createAccountSuccess,
   createAccountFailure,
@@ -14,9 +17,25 @@ import {
 import { Account } from '@/types/entities';
 import { CreateAccountPayload, UpdateAccountPayload } from '@/types/requests';
 
+function* handleFetchAccounts(action: ReturnType<typeof fetchAccountsRequest>) {
+  try {
+    const { search } = action.payload;
+    const endpoint = search ? `/api/accounts?search=${search}` : '/api/accounts';
+    const response: { success: boolean, result: Account[], response: string } = yield call(fetchData, endpoint);
+    if (response.success) {
+      yield put(fetchAccountsSuccess(response.result));
+    } else {
+      yield put(fetchAccountsFailure(response.response || 'Failed to fetch accounts'));
+    }
+  } catch (error) {
+    const err = error as Error;
+    yield put(fetchAccountsFailure(err.message || 'An unknown error occurred'));
+  }
+}
+
 function* handleCreateAccount(action: ReturnType<typeof createAccountRequest>) {
   try {
-    const response: { success: boolean, result: Account, response: string } = yield call(postData<CreateAccountPayload>, '/api/accounts', action.payload);
+    const response: { success: boolean, result: Account, response: string } = yield call(postData<CreateAccountPayload>, '/api/add/account', action.payload);
     if (response.success) {
       yield put(createAccountSuccess(response.result));
     } else {
@@ -48,7 +67,7 @@ function* handleDeleteAccount(action: ReturnType<typeof deleteAccountRequest>) {
     const { accountId } = action.payload;
     const response: { success: boolean, response: string } = yield call(deleteData, `/api/accounts/${accountId}`);
     if (response.success) {
-      yield put(deleteAccountSuccess());
+      yield put(deleteAccountSuccess({ accountId }));
     } else {
       yield put(deleteAccountFailure(response.response || 'Failed to delete account'));
     }
@@ -59,6 +78,7 @@ function* handleDeleteAccount(action: ReturnType<typeof deleteAccountRequest>) {
 }
 
 function* watchAccount() {
+  yield takeLatest(fetchAccountsRequest.type, handleFetchAccounts);
   yield takeLatest(createAccountRequest.type, handleCreateAccount);
   yield takeLatest(updateAccountRequest.type, handleUpdateAccount);
   yield takeLatest(deleteAccountRequest.type, handleDeleteAccount);

--- a/src/store/account/accountSlice.ts
+++ b/src/store/account/accountSlice.ts
@@ -3,13 +3,15 @@ import { Account } from '@/types/entities';
 import { CreateAccountPayload, UpdateAccountPayload } from '@/types/requests';
 
 interface AccountState {
-  account: Account | null;
+  accounts: Account[];
+  selectedAccount: Account | null;
   loading: boolean;
   error: string | null;
 }
 
 const initialState: AccountState = {
-  account: null,
+  accounts: [],
+  selectedAccount: null,
   loading: false,
   error: null,
 };
@@ -18,13 +20,26 @@ const accountSlice = createSlice({
   name: 'account',
   initialState,
   reducers: {
+    fetchAccountsRequest(state, _action: PayloadAction<{ search?: string }>) {
+      state.loading = true;
+      state.error = null;
+    },
+    fetchAccountsSuccess(state, action: PayloadAction<Account[]>) {
+      state.loading = false;
+      state.accounts = action.payload;
+    },
+    fetchAccountsFailure(state, action: PayloadAction<string>) {
+      state.loading = false;
+      state.error = action.payload;
+    },
     createAccountRequest(state, _action: PayloadAction<CreateAccountPayload>) {
       state.loading = true;
       state.error = null;
     },
     createAccountSuccess(state, action: PayloadAction<Account>) {
       state.loading = false;
-      state.account = action.payload;
+      state.selectedAccount = action.payload;
+      state.accounts.push(action.payload);
     },
     createAccountFailure(state, action: PayloadAction<string>) {
       state.loading = false;
@@ -36,7 +51,11 @@ const accountSlice = createSlice({
     },
     updateAccountSuccess(state, action: PayloadAction<Account>) {
       state.loading = false;
-      state.account = action.payload;
+      state.selectedAccount = action.payload;
+      const index = state.accounts.findIndex(account => account.accountId === action.payload.accountId);
+      if (index !== -1) {
+        state.accounts[index] = action.payload;
+      }
     },
     updateAccountFailure(state, action: PayloadAction<string>) {
       state.loading = false;
@@ -46,9 +65,12 @@ const accountSlice = createSlice({
       state.loading = true;
       state.error = null;
     },
-    deleteAccountSuccess(state) {
+    deleteAccountSuccess(state, action: PayloadAction<{ accountId: string }>) {
       state.loading = false;
-      state.account = null;
+      state.accounts = state.accounts.filter(account => account.accountId !== action.payload.accountId);
+      if (state.selectedAccount?.accountId === action.payload.accountId) {
+        state.selectedAccount = null;
+      }
     },
     deleteAccountFailure(state, action: PayloadAction<string>) {
       state.loading = false;
@@ -58,6 +80,9 @@ const accountSlice = createSlice({
 });
 
 export const {
+  fetchAccountsRequest,
+  fetchAccountsSuccess,
+  fetchAccountsFailure,
   createAccountRequest,
   createAccountSuccess,
   createAccountFailure,

--- a/src/store/brand/brandSaga.ts
+++ b/src/store/brand/brandSaga.ts
@@ -13,7 +13,7 @@ import { Brand } from '@/types/entities';
 function* handleFetchBrands(action: ReturnType<typeof fetchBrandsRequest>) {
   try {
     const { search } = action.payload;
-    const endpoint = search ? `/api/brands?search=${search}` : '/api/brands';
+    const endpoint = search ? `/api/list/venues?search=${search}` : '/api/list/venues';
     const response: { success: boolean, result: Brand[], response: string } = yield call(fetchData, endpoint);
     if (response.success) {
       yield put(fetchBrandsSuccess(response.result));
@@ -29,7 +29,7 @@ function* handleFetchBrands(action: ReturnType<typeof fetchBrandsRequest>) {
 function* handleDeleteBrand(action: ReturnType<typeof deleteBrandRequest>) {
   try {
     const { brandId } = action.payload;
-    const response: { success: boolean, response: string } = yield call(deleteData, `/api/brands/${brandId}`);
+    const response: { success: boolean, response: string } = yield call(deleteData, `/api/list/venues/${brandId}`);
     if (response.success) {
       yield put(deleteBrandSuccess({ brandId }));
     } else {


### PR DESCRIPTION
This commit builds on the previous Redux setup.

- Adds functionality to fetch a list of accounts.
- Updates the account slice and state to handle a list of accounts in addition to a selected account.
- Changes the account creation API endpoint to `/api/add/account`.
- Changes the brand/venue list and search API endpoint to `/api/list/venues` for both fetch and delete operations.