### PR TITLE
fix: Implement robust JWT authentication handling

### DIFF
--- a/src/store/StoreProvider.tsx
+++ b/src/store/StoreProvider.tsx
@@ -4,18 +4,36 @@ import { Provider, useDispatch } from "react-redux";
 import { store } from "./store";
 import { useEffect } from "react";
 import { authCheckCompleted } from "./auth/authSlice";
+import { setAuthToken } from "@/services/apiHelper";
+import CryptoJS from 'crypto-js';
+
+const secretPass = 'al123@st678$ven';
 
 // A component to handle the auth rehydration
 function AuthRehydrator({ children }: { children: React.ReactNode }) {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    const token = document.cookie
-      .split('; ')
-      .find(row => row.startsWith('token='))
-      ?.split('=')[1];
+    let isAuthenticated = false;
+    const encryptedToken = localStorage.getItem('token');
 
-    dispatch(authCheckCompleted({ isAuthenticated: !!token }));
+    if (encryptedToken) {
+      try {
+        const decryptedBytes = CryptoJS.AES.decrypt(encryptedToken, secretPass);
+        const decryptedToken = decryptedBytes.toString(CryptoJS.enc.Utf8);
+
+        if (decryptedToken) {
+          const token = JSON.parse(decryptedToken);
+          setAuthToken(token); // Apply token to axios instance
+          isAuthenticated = true;
+        }
+      } catch (e) {
+        console.error("Failed to decrypt token on load, logging out.", e);
+        setAuthToken(null); // Clear any invalid token
+      }
+    }
+
+    dispatch(authCheckCompleted({ isAuthenticated }));
   }, [dispatch]);
 
   return <>{children}</>;


### PR DESCRIPTION
This commit refactors the application's authentication mechanism to ensure the JWT Authorization header is reliably sent with all API requests after login.

- Replaces the request interceptor with a more robust pattern.
- The `setAuthToken` function now directly sets the default `Authorization` header on the global axios instance.
- Implements an authentication rehydration process in the `StoreProvider` to load the token from localStorage on application startup, ensuring sessions persist across page reloads.
- This fixes a critical bug where API calls were being made without the necessary authentication token.