### PR TITLE
Fix mobile UI issues in accounts pages

### DIFF
--- a/src/app/(features)/businesses/accounts/page.tsx
+++ b/src/app/(features)/businesses/accounts/page.tsx
@@ -136,12 +136,8 @@ export default function AccountsPage() {
 
   return (
     <div>
-      <div className="py-[13px] bg-white hidden md:block relative">
-        <div
-          className="absolute inset-0 bg-white"
-          style={{ left: "-100vw", right: "-100vw" }}
-        />
-        <div className="max-w-[1428px] mx-auto flex items-center justify-between relative z-10">
+      <div className="py-[13px] bg-white hidden md:block">
+        <div className="max-w-[1428px] mx-auto flex items-center justify-between">
           <div className="text-[18px] leading-[27px] w-[147px]">
             <SortDropdown onSelect={handleSortSelect} />
           </div>
@@ -180,13 +176,15 @@ export default function AccountsPage() {
           </div>
           {/* Mobile buttons */}
           <div className="md:hidden flex justify-end items-center mb-4 space-x-2">
-            <button
-              onClick={handleAddAccountClick}
-              className="bg-blue-500 text-white rounded-[11px] text-sm px-4 py-2"
-            >
-              Add Account
-            </button>
-            <div className="w-[137px]">
+            <div className="relative z-20">
+              <button
+                onClick={handleAddAccountClick}
+                className="bg-blue-500 text-white rounded-[11px] text-sm px-4 py-2"
+              >
+                Add Account
+              </button>
+            </div>
+            <div className="w-auto">
               <ActionDropdown
                 onSelect={handleActionSelect}
                 updateDisabled={checkedRows.size > 1}
@@ -206,6 +204,13 @@ export default function AccountsPage() {
                     onCheckboxChange={() => handleCheckboxChange(account.accountId)}
                   />
                 ))}
+                <Pagination
+                  totalItems={pagination.total}
+                  itemsPerPage={pagination.perPage}
+                  currentPage={pagination.currentPage}
+                  onPageChange={handlePageChange}
+                  onItemsPerPageChange={handleItemsPerPageChange}
+                />
               </div>
               <div className="hidden md:block">
                 <AccountsTable

--- a/src/components/features/accounts/AccountDetails.tsx
+++ b/src/components/features/accounts/AccountDetails.tsx
@@ -168,7 +168,7 @@ export default function AccountDetails({ account, onSave }: AccountDetailsProps)
             initialSelectedBrands={formData.brands || []}
             onChange={handleBrandChange}
           />
-          <div className="flex justify-end gap-4 mt-6">
+          <div className="flex justify-end gap-4 mt-6 flex-shrink-0">
             <button
               type="button"
               onClick={() => router.back()}


### PR DESCRIPTION
This commit fixes several UI issues on mobile and small screens related to the accounts feature.

The following issues have been addressed:
- The header is no longer hidden after login or navigation. This was caused by a div with a large negative offset that was causing horizontal overflow.
- Pagination is now displayed on the accounts list on small screens.
- The 'Cancel' and 'Submit' buttons on the add/edit account form are now correctly displayed. A `flex-shrink-0` class has been added to the button container to prevent it from shrinking.
- The 'Add Account' button in the list is now working correctly. The button was wrapped in a div with a higher z-index to prevent it from being overlapped by other elements.