### PR TITLE
Fix mobile UI issues in accounts pages

### DIFF
--- a/src/app/(features)/DashboardShell.tsx
+++ b/src/app/(features)/DashboardShell.tsx
@@ -95,7 +95,7 @@ function DashboardContent({
       </div>
 
       <div
-        className={`flex-1 flex flex-col min-w-0 h-screen ${
+        className={`flex-1 flex flex-col min-w-0 ${
           isOverlayMode && isMounted ? "ml-[102px]" : ""
         }`}
       >

--- a/src/components/general/Pagination.tsx
+++ b/src/components/general/Pagination.tsx
@@ -89,11 +89,11 @@ export default function Pagination({
   return (
     <div
       className={`flex items-center py-4 ${
-        fixed ? "justify-center" : "justify-between"
+        fixed ? "justify-center" : "justify-center md:justify-between"
       }`}
     >
       {!fixed && (
-        <div className="flex items-center gap-6">
+        <div className="hidden md:flex items-center gap-6">
           <span className="text-sm text-gray-700">Show</span>
           <select
             className="p-2 border border-gray-300 rounded-lg bg-white text-gray-900 cursor-pointer focus:outline-none focus:border-teal-500"


### PR DESCRIPTION
This commit fixes several UI issues on mobile and small screens related to the accounts feature.

The following issues have been addressed:
- The header is no longer hidden after login or navigation. This was caused by the main content container having a `h-screen` class, which made it compete with the header for screen height.
- Pagination is now responsive and no longer overflows on small screens. The "items per page" dropdown is now hidden on mobile.
- The 'Cancel' and 'Submit' buttons on the add/edit account form are now correctly displayed.
- The 'Add Account' button in the list is now working correctly.