### PR TITLE
fix: Correct text truncation in account mobile card

### DIFF
--- a/src/components/features/accounts/AccountMobileCard.tsx
+++ b/src/components/features/accounts/AccountMobileCard.tsx
@@ -43,7 +43,7 @@ export default function AccountMobileCard({
                 {account.avatarInitials}
               </span>
             </div>
-            <div className="flex flex-col flex-1 w-0">
+            <div className="flex flex-col flex-1 min-w-0">
               <h3 className="text-[15px] text-[#4F4F4F] font-semibold leading-[1.5] truncate">
                 {getDisplayName(account)}
               </h3>


### PR DESCRIPTION
This commit fixes a regression where text (name, email, phone) was not showing up in the account mobile card. The `w-0` class, intended to help with truncation, was causing the text container to collapse. This has been replaced with `min-w-0`, which correctly allows the text to be displayed and truncated.