### PR TITLE
feat: Disable Action dropdown when no items are selected

### DIFF
--- a/src/app/(features)/businesses/accounts/page.tsx
+++ b/src/app/(features)/businesses/accounts/page.tsx
@@ -186,6 +186,7 @@ export default function AccountsPage() {
               <ActionDropdown
                 onSelect={handleActionSelect}
                 updateDisabled={checkedRows.size > 1}
+                disabled={checkedRows.size === 0}
               />
             </div>
           </div>
@@ -203,6 +204,7 @@ export default function AccountsPage() {
               <ActionDropdown
                 onSelect={handleActionSelect}
                 updateDisabled={checkedRows.size > 1}
+                disabled={checkedRows.size === 0}
               />
             </div>
           </div>

--- a/src/components/general/dropdowns/ActionDropdown.tsx
+++ b/src/components/general/dropdowns/ActionDropdown.tsx
@@ -5,11 +5,13 @@ import { Dropdown } from "@/components/general/dropdowns/Dropdown";
 interface ActionDropdownProps {
   onSelect?: (value: string) => void;
   updateDisabled?: boolean;
+  disabled?: boolean;
 }
 
 export default function ActionDropdown({
   onSelect,
   updateDisabled,
+  disabled,
 }: ActionDropdownProps) {
   const options = [
     {
@@ -66,6 +68,7 @@ export default function ActionDropdown({
       onSelect={handleSelect}
       buttonClassName="pt-1.25 pb-1.75 bg-[#00A4B6] border-0 rounded-[11px] flex items-center justify-between w-full"
       icon="/icons/general/dropdownarrow-1-white.svg"
+      disabled={disabled}
     />
   );
 }

--- a/src/components/general/dropdowns/Dropdown.tsx
+++ b/src/components/general/dropdowns/Dropdown.tsx
@@ -29,6 +29,7 @@ interface DropdownProps<T> {
   icon?: string; // path to SVG image
   buttonClassName?: string; // extra Tailwind classes
   menuItemsClassName?: string;
+  disabled?: boolean;
 }
 
 export function Dropdown<T>(props: DropdownProps<T>) {
@@ -54,6 +55,7 @@ export function Dropdown<T>(props: DropdownProps<T>) {
       shadow-lg max-h-60 overflow-auto z-10
       focus:outline-none 
     `.trim(),
+    disabled = false,
   } = props;
 
   // uncontrolled state for select mode
@@ -74,9 +76,10 @@ export function Dropdown<T>(props: DropdownProps<T>) {
           if (controlled === undefined) setInternal(val);
           onSelect(val);
         }}
+        disabled={disabled}
       >
         <div className="relative text-left">
-          <ListboxButton className={buttonClassName}>
+          <ListboxButton className={`${buttonClassName} disabled:opacity-50 disabled:cursor-not-allowed`}>
             <div className="truncate flex-1">{displayLabel}</div>
             <div className="mr-3">
               <Image
@@ -118,7 +121,10 @@ export function Dropdown<T>(props: DropdownProps<T>) {
   // —— action mode ——
   return (
     <Menu as="div" className="relative w-full text-left">
-      <MenuButton className={buttonClassName}>
+      <MenuButton
+        className={`${buttonClassName} disabled:opacity-50 disabled:cursor-not-allowed`}
+        disabled={disabled}
+      >
         <div className="truncate flex-1">{displayLabel}</div>
         <div className="mr-3">
           <Image


### PR DESCRIPTION
This commit disables the 'Action' dropdown on the accounts list page when no accounts are selected. The dropdown is now enabled only after at least one account is checked.