### PR TITLE
Fix multiple UI and login issues

### DIFF
--- a/src/app/(features)/businesses/accounts/page.tsx
+++ b/src/app/(features)/businesses/accounts/page.tsx
@@ -222,7 +222,7 @@ export default function AccountsPage() {
                   />
                 ))}
                 {accounts.length < pagination.total && (
-                  <div className="text-center font-semibold text-[15px] text-gray-500 my-4">
+                  <div className="text-center font-semibold text-[15px] text-gray-500 my-4 mb-8">
                     <button
                       onClick={handleSeeMore}
                       disabled={loading}

--- a/src/components/features/accounts/AccountDetails.tsx
+++ b/src/components/features/accounts/AccountDetails.tsx
@@ -186,7 +186,7 @@ export default function AccountDetails({ account, onSave }: AccountDetailsProps)
             initialSelectedBrands={formData.brands || []}
             onChange={handleBrandChange}
           />
-          <div className="flex justify-end gap-4 mt-6 flex-shrink-0">
+          <div className="flex justify-end gap-4 mt-6 flex-shrink-0 mb-4 md:mb-0">
             <button
               type="button"
               onClick={() => router.back()}

--- a/src/store/account/accountSaga.ts
+++ b/src/store/account/accountSaga.ts
@@ -66,6 +66,7 @@ interface ApiAccount {
   phone: string;
   country_code: string;
   account_type: string;
+  status: "active" | "inactive";
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   venues: any[];
   created_at: string;
@@ -120,6 +121,7 @@ function* handleFetchAccounts(action: ReturnType<typeof fetchAccountsRequest>) {
         subscriptionCount: 0,
         brandsCount: apiAccount.venues?.length || 0,
         campaignsCount: 0,
+        status: apiAccount.status,
       }));
 
       yield put(fetchAccountsSuccess({
@@ -176,6 +178,7 @@ function* handleFetchMoreAccounts(action: ReturnType<typeof fetchMoreAccountsReq
         subscriptionCount: 0,
         brandsCount: apiAccount.venues?.length || 0,
         campaignsCount: 0,
+        status: apiAccount.status,
       }));
 
       yield put(fetchMoreAccountsSuccess({
@@ -245,6 +248,7 @@ function* handleCreateAccount(action: ReturnType<typeof createAccountRequest>) {
         subscriptionCount: 0,
         brandsCount: apiAccount.venues.length,
         campaignsCount: 0,
+        status: apiAccount.status,
       };
 
       yield put(createAccountSuccess(feAccount));
@@ -318,6 +322,7 @@ function* handleUpdateAccount(action: ReturnType<typeof updateAccountRequest>) {
         subscriptionCount: 0,
         brandsCount: apiAccount.venues?.length || 0,
         campaignsCount: 0,
+        status: apiAccount.status,
       };
       yield put(updateAccountSuccess(feAccount));
       toast.success(response.message);
@@ -377,6 +382,7 @@ function* handleFetchAccountById(action: ReturnType<typeof fetchAccountByIdReque
         subscriptionCount: 0,
         brandsCount: apiAccount.venues?.length || 0,
         campaignsCount: 0,
+        status: apiAccount.status,
       };
       yield put(fetchAccountByIdSuccess(feAccount));
     } else {


### PR DESCRIPTION
This commit addresses five separate issues:

1.  Adds an "(Inactive)" label in red to the account edit form for inactive accounts.
2.  Removes the "Plans" tab from the account add/edit form.
3.  Restricts all phone number fields to only accept numeric characters.
4.  Fixes a glitch where the mobile number entry page appears when logging into the admin portal.
5.  Fixes a bug where users are redirected to the dashboard after entering their phone number, without entering an OTP or captcha.

This commit also addresses the following feedback:
- The "(Inactive)" label is now correctly displayed by fetching the status from the API.
- The bottom margin/padding for the cancel/submit buttons and the "See More" button has been increased for better mobile visibility.