### PR TITLE
Fix multiple UI and login issues

### DIFF
--- a/src/app/(features)/businesses/accounts/page.tsx
+++ b/src/app/(features)/businesses/accounts/page.tsx
@@ -150,14 +150,14 @@ export default function AccountsPage() {
 
   return (
     <div>
-      <div className="py-[13px] bg-white hidden md:block relative">
+      {/* <div className="py-[13px] bg-white hidden md:block relative">
         <div className="absolute inset-0 bg-white" style={{left: '-100vw', right: '-100vw'}}></div>
         <div className="max-w-[1428px] mx-auto flex items-center justify-between relative z-10">
           <div className="text-[18px] leading-[27px]">
             <SortDropdown onSelect={handleSortSelect} />
           </div>
         </div>
-      </div>
+      </div> */}
       <div className="md:hidden pt-4 flex items-center gap-[7px]">
         <SearchInputMobile
           value={search}


### PR DESCRIPTION
This commit addresses several issues:

1.  Adds an "(Inactive)" label in red to the account edit form for inactive accounts.
2.  Removes the "Plans" tab from the account add/edit form.
3.  Restricts all phone number fields to only accept numeric characters.
4.  Fixes a glitch where the mobile number entry page appears when logging into the admin portal.
5.  Fixes a bug where users are redirected to the dashboard after entering their phone number, without entering an OTP or captcha.
6.  Comments out the sort dropdown from the account list.
7.  Verifies that the search functionality is implemented correctly.

This commit also addresses the following feedback:
- The "(Inactive)" label is now correctly displayed by fetching the status from the API.
- The bottom margin/padding for the cancel/submit buttons and the "See More" button has been increased for better mobile visibility.
- A bug where the OTP page would reset to the phone number entry page has been fixed.