### PR TITLE
Fix multiple UI and login issues and implement common search

### DIFF
--- a/src/app/(features)/businesses/accounts/page.tsx
+++ b/src/app/(features)/businesses/accounts/page.tsx
@@ -28,13 +28,13 @@ export default function AccountsPage() {
     bulkUpdateStatusError,
   } = useSelector((state: RootState) => state.account);
 
-  const [search, setSearch] = useState("");
+  const { searchTerm } = useSelector((state: RootState) => state.search);
   const [status, setStatus] = useState("");
   const [accountType, setAccountType] = useState("");
   const [checkedRows, setCheckedRows] = useState<Set<string>>(new Set());
   const [mobilePage, setMobilePage] = useState(1);
 
-  const debouncedSearch = useDebounce(search, 500);
+  const debouncedSearch = useDebounce(searchTerm, 500);
   // Effect for initial load
   useEffect(() => {
     if (accounts.length === 0) {
@@ -76,7 +76,7 @@ export default function AccountsPage() {
   const handlePageChange = (page: number) => {
     dispatch(fetchAccountsRequest({
       page,
-      search: search,
+      search: searchTerm,
       status: status,
       account_type: accountType,
       per_page: pagination.perPage
@@ -84,22 +84,18 @@ export default function AccountsPage() {
   };
 
   const handleItemsPerPageChange = (items: number) => {
-    dispatch(fetchAccountsRequest({ search, status, account_type: accountType, per_page: items, page: 1 }));
+    dispatch(fetchAccountsRequest({ search: searchTerm, status, account_type: accountType, per_page: items, page: 1 }));
   };
 
-  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearch(e.target.value);
-  };
-
-  const handleSortSelect = (value: string) => {
-    const [key, val] = value.split(':');
-    if (key === 'status') {
-      setStatus(val);
-    }
-    if (key === 'account_type') {
-      setAccountType(val);
-    }
-  };
+  // const handleSortSelect = (value: string) => {
+  //   const [key, val] = value.split(':');
+  //   if (key === 'status') {
+  //     setStatus(val);
+  //   }
+  //   if (key === 'account_type') {
+  //     setAccountType(val);
+  //   }
+  // };
 
   const handleActionSelect = (value: string) => {
     if (value === "update") {
@@ -136,7 +132,7 @@ export default function AccountsPage() {
     const nextPage = mobilePage + 1;
     dispatch(fetchMoreAccountsRequest({
       page: nextPage,
-      search: search,
+      search: searchTerm,
       status: status,
       account_type: accountType,
       per_page: 10
@@ -159,11 +155,6 @@ export default function AccountsPage() {
         </div>
       </div> */}
       <div className="md:hidden pt-4 flex items-center gap-[7px]">
-        <SearchInputMobile
-          value={search}
-          onChange={handleSearchChange}
-          placeholder="Search account"
-        />
         <div className="bg-white rounded-[11px] w-10 h-10  flex items-center justify-center aspect-square">
           <Image
             src="/icons/general/sort-1-light.svg"

--- a/src/components/general/SearchInput.tsx
+++ b/src/components/general/SearchInput.tsx
@@ -1,7 +1,16 @@
-// SearchInput.jsx
 import Image from "next/image";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "@/store/store";
+import { setSearchTerm } from "@/store/search/searchSlice";
 
 export default function SearchInput() {
+  const dispatch = useDispatch();
+  const { searchTerm } = useSelector((state: RootState) => state.search);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch(setSearchTerm(e.target.value));
+  };
+
   return (
     <div className="relative max-w-[341px]">
       <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
@@ -16,6 +25,8 @@ export default function SearchInput() {
       <input
         type="text"
         placeholder="Search"
+        value={searchTerm}
+        onChange={handleChange}
         className="
           text-[18px]
           block

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -2,11 +2,13 @@ import { combineReducers } from '@reduxjs/toolkit';
 import authReducer from './auth/authSlice';
 import accountReducer from './account/accountSlice';
 import brandReducer from './brand/brandSlice';
+import searchReducer from './search/searchSlice';
 
 const rootReducer = combineReducers({
   auth: authReducer,
   account: accountReducer,
   brand: brandReducer,
+  search: searchReducer,
 });
 
 export default rootReducer;

--- a/src/store/search/searchSlice.ts
+++ b/src/store/search/searchSlice.ts
@@ -1,0 +1,22 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface SearchState {
+  searchTerm: string;
+}
+
+const initialState: SearchState = {
+  searchTerm: '',
+};
+
+const searchSlice = createSlice({
+  name: 'search',
+  initialState,
+  reducers: {
+    setSearchTerm(state, action: PayloadAction<string>) {
+      state.searchTerm = action.payload;
+    },
+  },
+});
+
+export const { setSearchTerm } = searchSlice.actions;
+export default searchSlice.reducer;


### PR DESCRIPTION
This commit addresses several issues:

1.  Adds an "(Inactive)" label in red to the account edit form for inactive accounts.
2.  Removes the "Plans" tab from the account add/edit form.
3.  Restricts all phone number fields to only accept numeric characters.
4.  Fixes a glitch where the mobile number entry page appears when logging into the admin portal.
5.  Fixes a bug where users are redirected to the dashboard after entering their phone number, without entering an OTP or captcha.
6.  Comments out the sort dropdown and function from the account list.
7.  Implements a common search box in the header.

This commit also addresses the following feedback:
- The "(Inactive)" label is now correctly displayed by fetching the status from the API.
- The bottom margin/padding for the cancel/submit buttons and the "See More" button has been increased for better mobile visibility.
- A bug where the OTP page would reset to the phone number entry page has been fixed.