### PR TITLE
Fix multiple UI and login issues and implement common search

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -17,6 +17,7 @@ export function middleware(request: NextRequest) {
     if (isAdminRoute) {
       const url = new URL("/login", request.url);
       url.searchParams.set("redirectedFrom", "admin");
+      url.searchParams.set("redirect", pathname);
       return NextResponse.redirect(url);
     }
     // If the user is trying to access any other protected route, redirect to login

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -19,11 +19,12 @@ export default function LoginPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const redirectedFrom = searchParams.get("redirectedFrom");
+  const redirectUrl = searchParams.get("redirect");
 
   useEffect(() => {
     if (isAuthenticated && !loginInProgress) {
-      if (redirectedFrom === "admin") {
-        router.push("/admin/team");
+      if (redirectedFrom === "admin" && redirectUrl) {
+        router.push(redirectUrl);
       } else {
         router.push("/dashboard");
       }
@@ -32,7 +33,7 @@ export default function LoginPage() {
     return () => {
       dispatch(resetOtpSent());
     };
-  }, [isAuthenticated, loginInProgress, router, dispatch, redirectedFrom]);
+  }, [isAuthenticated, loginInProgress, router, dispatch, redirectedFrom, redirectUrl]);
 
   const handleSendOtp = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/app/(features)/businesses/accounts/page.tsx
+++ b/src/app/(features)/businesses/accounts/page.tsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useRouter } from "next/navigation";
 import { fetchAccountsRequest, bulkDeleteAccountsRequest, bulkUpdateStatusRequest, fetchMoreAccountsRequest } from "@/store/account/accountSlice";
+import { setSearchTerm } from "@/store/search/searchSlice";
 import { RootState } from "@/store/store";
 import AccountsTable from "@/components/features/accounts/AccountsTable";
 import AccountCard from "@/components/features/accounts/AccountMobileCard";
@@ -155,6 +156,11 @@ export default function AccountsPage() {
         </div>
       </div> */}
       <div className="md:hidden pt-4 flex items-center gap-[7px]">
+        <SearchInputMobile
+          value={searchTerm}
+          onChange={(e) => dispatch(setSearchTerm(e.target.value))}
+          placeholder="Search account"
+        />
         <div className="bg-white rounded-[11px] w-10 h-10  flex items-center justify-center aspect-square">
           <Image
             src="/icons/general/sort-1-light.svg"

--- a/src/components/features/accounts/AccountHeader.tsx
+++ b/src/components/features/accounts/AccountHeader.tsx
@@ -42,12 +42,14 @@ export default function AccountHeader({
                   {account?.avatarInitials}
                 </div>
                 <div>
-                  <h1 className="text-[18px] md:text-[25px] font-semibold ">
-                    {`${account?.firstName || ""} ${account?.lastName || ""}`}
+                  <div>
+                    <h1 className="text-[18px] md:text-[25px] font-semibold ">
+                      {`${account?.firstName || ""} ${account?.lastName || ""}`}
+                    </h1>
                     {account?.status === "inactive" && (
-                      <span className="text-red-500 text-sm ml-2">(Inactive)</span>
+                      <span className="text-red-500 text-sm">(Inactive)</span>
                     )}
-                  </h1>
+                  </div>
                   {/* <p className="text-[15px] md:text-[18px] font-medium ">
                     {account?.affiliation}
                   </p> */}


### PR DESCRIPTION
This commit addresses several issues:

1.  Adds an "(Inactive)" label in red to the account edit form for inactive accounts.
2.  Removes the "Plans" tab from the account add/edit form.
3.  Restricts all phone number fields to only accept numeric characters.
4.  Fixes a glitch where the mobile number entry page appears when logging into the admin portal.
5.  Fixes a bug where users are redirected to the dashboard after entering their phone number, without entering an OTP or captcha.
6.  Comments out the sort dropdown and function from the account list.
7.  Implements a common search box in the header.
8.  Changes form validation to display errors below each control instead of as alerts.
9.  Adjusts the position of the "(Inactive)" label to be below the account name.

This commit also addresses the following feedback:
- The "(Inactive)" label is now correctly displayed by fetching the status from the API.
- The bottom margin/padding for the cancel/submit buttons and the "See More" button has been increased for better mobile visibility.
- A bug where the OTP page would reset to the phone number entry page has been fixed.