### PR TITLE
Fix multiple UI and login issues and implement common search

### DIFF
--- a/src/components/features/accounts/AccountDetails.tsx
+++ b/src/components/features/accounts/AccountDetails.tsx
@@ -108,7 +108,9 @@ export default function AccountDetails({ account, onSave }: AccountDetailsProps)
 
     requiredFields.forEach((field) => {
       if (!formData[field]) {
-        newErrors[field] = `${field.replace(/([A-Z])/g, " $1")} is required.`;
+        const label = field.replace(/([A-Z])/g, " $1");
+        const capitalizedLabel = label.charAt(0).toUpperCase() + label.slice(1);
+        newErrors[field] = `${capitalizedLabel} is required.`;
       }
     });
 


### PR DESCRIPTION
This commit addresses several issues:

1.  Adds an "(Inactive)" label in red to the account edit form for inactive accounts.
2.  Removes the "Plans" tab from the account add/edit form.
3.  Restricts all phone number fields to only accept numeric characters.
4.  Fixes a glitch where the mobile number entry page appears when logging into the admin portal.
5.  Fixes a bug where users are redirected to the dashboard after entering their phone number, without entering an OTP or captcha.
6.  Comments out the sort dropdown and function from the account list.
7.  Implements a common search box in the header.
8.  Changes form validation to display errors below each control instead of as alerts.
9.  Adjusts the position of the "(Inactive)" label to be below the account name.
10. Capitalizes the first letter of each control for validation texts.

This commit also addresses the following feedback:
- The "(Inactive)" label is now correctly displayed by fetching the status from the API.
- The bottom margin/padding for the cancel/submit buttons and the "See More" button has been increased for better mobile visibility.
- A bug where the OTP page would reset to the phone number entry page has been fixed.