### PR TITLE
Fix multiple UI and login issues and implement common search

### DIFF
--- a/src/app/(features)/businesses/accounts/[accountId]/page.tsx
+++ b/src/app/(features)/businesses/accounts/[accountId]/page.tsx
@@ -12,6 +12,7 @@ import {
   updateAccountRequest,
   fetchAccountByIdRequest,
   resetUpdateStatus,
+  clearSelectedAccount,
 } from "@/store/account/accountSlice";
 import { CreateAccountPayload, UpdateAccountPayload } from "@/types/requests";
 
@@ -33,6 +34,7 @@ export default function AccountPage() {
 
   useEffect(() => {
     if (isCreateMode) {
+      dispatch(clearSelectedAccount());
       setAccount({
         firstName: "",
         lastName: "",

--- a/src/store/account/accountSlice.ts
+++ b/src/store/account/accountSlice.ts
@@ -149,6 +149,9 @@ const accountSlice = createSlice({
     resetUpdateStatus(state) {
       state.updateSuccess = false;
     },
+    clearSelectedAccount(state) {
+      state.selectedAccount = null;
+    },
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     bulkDeleteAccountsRequest(state, _action: PayloadAction<{ account_ids: string[] }>) {
       state.bulkDeleteInProgress = true;
@@ -202,6 +205,7 @@ export const {
   fetchAccountByIdSuccess,
   fetchAccountByIdFailure,
   resetUpdateStatus,
+  clearSelectedAccount,
   bulkDeleteAccountsRequest,
   bulkDeleteAccountsSuccess,
   bulkDeleteAccountsFailure,


### PR DESCRIPTION
This commit addresses several issues:

1.  Adds an "(Inactive)" label in red to the account edit form for inactive accounts.
2.  Removes the "Plans" tab from the account add/edit form.
3.  Restricts all phone number fields to only accept numeric characters.
4.  Fixes a glitch where the mobile number entry page appears when logging into the admin portal.
5.  Fixes a bug where users are redirected to the dashboard after entering their phone number, without entering an OTP or captcha.
6.  Comments out the sort dropdown and function from the account list.
7.  Implements a common search box in the header.
8.  Changes form validation to display errors below each control instead of as alerts.
9.  Adjusts the position of the "(Inactive)" label to be below the account name.
10. Capitalizes the first letter of each control for validation texts.
11. Fixes a bug where the "Add Account" button does not work after editing an account.

This commit also addresses the following feedback:
- The "(Inactive)" label is now correctly displayed by fetching the status from the API.
- The bottom margin/padding for the cancel/submit buttons and the "See More" button has been increased for better mobile visibility.
- A bug where the OTP page would reset to the phone number entry page has been fixed.