### PR TITLE
Fix multiple UI and login issues and implement common search

### DIFF
--- a/src/app/(features)/businesses/accounts/[accountId]/page.tsx
+++ b/src/app/(features)/businesses/accounts/[accountId]/page.tsx
@@ -12,7 +12,7 @@ import {
   updateAccountRequest,
   fetchAccountByIdRequest,
   resetUpdateStatus,
-  clearSelectedAccount,
+  resetCreateStatus,
 } from "@/store/account/accountSlice";
 import { CreateAccountPayload, UpdateAccountPayload } from "@/types/requests";
 
@@ -25,7 +25,7 @@ export default function AccountPage() {
   const accountId = params.accountId as string;
   const isCreateMode = accountId === "create";
 
-  const { selectedAccount, loading, error, updateSuccess } = useSelector(
+  const { selectedAccount, loading, error, updateSuccess, createSuccess } = useSelector(
     (state: RootState) => state.account
   );
 
@@ -34,7 +34,6 @@ export default function AccountPage() {
 
   useEffect(() => {
     if (isCreateMode) {
-      dispatch(clearSelectedAccount());
       setAccount({
         firstName: "",
         lastName: "",
@@ -56,8 +55,9 @@ export default function AccountPage() {
 
   // Handle successful creation or update
   useEffect(() => {
-    if (isCreateMode && selectedAccount?.accountId) {
+    if (createSuccess) {
       router.push("/businesses/accounts");
+      dispatch(resetCreateStatus()); // Reset the flag
     }
 
     if (updateSuccess) {
@@ -65,10 +65,9 @@ export default function AccountPage() {
       dispatch(resetUpdateStatus()); // Reset the flag
     }
   }, [
-    selectedAccount,
-    isCreateMode,
-    router,
+    createSuccess,
     updateSuccess,
+    router,
     dispatch,
   ]);
 

--- a/src/store/account/accountSlice.ts
+++ b/src/store/account/accountSlice.ts
@@ -16,6 +16,7 @@ interface AccountState {
   error: string | null;
   pagination: PaginationState;
   updateSuccess: boolean;
+  createSuccess: boolean;
   bulkDeleteInProgress: boolean;
   bulkDeleteError: string | null;
   bulkUpdateStatusInProgress: boolean;
@@ -34,6 +35,7 @@ const initialState: AccountState = {
     total: 0,
   },
   updateSuccess: false,
+  createSuccess: false,
   bulkDeleteInProgress: false,
   bulkDeleteError: null,
   bulkUpdateStatusInProgress: false,
@@ -88,11 +90,13 @@ const accountSlice = createSlice({
     createAccountRequest(state, _action: PayloadAction<CreateAccountPayload>) {
       state.loading = true;
       state.error = null;
+      state.createSuccess = false;
     },
     createAccountSuccess(state, action: PayloadAction<Account>) {
       state.loading = false;
       state.selectedAccount = action.payload;
       state.accounts.push(action.payload);
+      state.createSuccess = true;
     },
     createAccountFailure(state, action: PayloadAction<string>) {
       state.loading = false;
@@ -149,8 +153,8 @@ const accountSlice = createSlice({
     resetUpdateStatus(state) {
       state.updateSuccess = false;
     },
-    clearSelectedAccount(state) {
-      state.selectedAccount = null;
+    resetCreateStatus(state) {
+      state.createSuccess = false;
     },
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     bulkDeleteAccountsRequest(state, _action: PayloadAction<{ account_ids: string[] }>) {
@@ -205,7 +209,7 @@ export const {
   fetchAccountByIdSuccess,
   fetchAccountByIdFailure,
   resetUpdateStatus,
-  clearSelectedAccount,
+  resetCreateStatus,
   bulkDeleteAccountsRequest,
   bulkDeleteAccountsSuccess,
   bulkDeleteAccountsFailure,


### PR DESCRIPTION
This commit addresses several issues:

1.  Adds an "(Inactive)" label in red to the account edit form for inactive accounts.
2.  Removes the "Plans" tab from the account add/edit form.
3.  Restricts all phone number fields to only accept numeric characters.
4.  Fixes a glitch where the mobile number entry page appears when logging into the admin portal.
5.  Fixes a bug where users are redirected to the dashboard after entering their phone number, without entering an OTP or captcha.
6.  Comments out the sort dropdown and function from the account list.
7.  Implements a common search box in the header.
8.  Changes form validation to display errors below each control instead of as alerts.
9.  Adjusts the position of the "(Inactive)" label to be below the account name.
10. Capitalizes the first letter of each control for validation texts.
11. Fixes a bug where the "Add Account" button does not work after editing an account.

This commit also addresses the following feedback:
- The "(Inactive)" label is now correctly displayed by fetching the status from the API.
- The bottom margin/padding for the cancel/submit buttons and the "See More" button has been increased for better mobile visibility.
- A bug where the OTP page would reset to the phone number entry page has been fixed.