### PR TITLE
Refactor: Fix multiple issues and add status badges

### DIFF
--- a/src/components/features/accounts/AccountMobileCard.tsx
+++ b/src/components/features/accounts/AccountMobileCard.tsx
@@ -53,8 +53,16 @@ export default function AccountMobileCard({
               <p className="text-[11px] text-[#686868] leading-[1.5] truncate">
                 {account.country_code} {account.phoneNumber}
               </p>
-              <p className="text-[11px] text-[#686868] leading-[1.5] truncate capitalize">
-                Status: {account.status}
+              <p className="text-[11px] text-[#686868] leading-[1.5] truncate">
+                <span
+                  className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
+                    account.status === 'active'
+                      ? 'bg-green-100 text-green-800'
+                      : 'bg-red-100 text-red-800'
+                  }`}
+                >
+                  {account.status}
+                </span>
               </p>
             </div>
           </div>

--- a/src/components/features/accounts/AccountsTable.tsx
+++ b/src/components/features/accounts/AccountsTable.tsx
@@ -132,8 +132,16 @@ export default function AccountsTable({
               <td className="px-6 py-2.5 whitespace-nowrap text-[15px] text-[#4F4F4F]">
                 {account.accountType}
               </td>
-              <td className="px-6 py-2.5 whitespace-nowrap text-[15px] text-[#4F4F4F] capitalize">
-                {account.status}
+              <td className="px-6 py-2.5 whitespace-nowrap text-[15px] text-[#4F4F4F]">
+                <span
+                  className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
+                    account.status === 'active'
+                      ? 'bg-green-100 text-green-800'
+                      : 'bg-red-100 text-red-800'
+                  }`}
+                >
+                  {account.status}
+                </span>
               </td>
               <td className="px-6 py-2.5 whitespace-nowrap text-[15px] text-[#4F4F4F] text-center">
                 {account.brandsCount}


### PR DESCRIPTION
This commit addresses five separate issues and a follow-up request:

1.  **Improved Validation Messages:** Updated the error handling for account creation and updates to display specific validation messages from the API. The error toast now shows a combination of the API error and a generic message.
2.  **Login Flow Glitch:** Fixed a visual glitch where the mobile number entry page would briefly reappear after a successful login. This was resolved by using a `useRef` to prevent premature state resets.
3.  **Pagination Visibility:** The pagination component is now always visible, even if there is only one page of data.
4.  **Display Country Code:** The country code is now displayed next to the phone number on the accounts list page for both mobile and desktop views.
5.  **Display Account Status:** An "active/inactive" status field has been added to the accounts list page. The status is displayed as a colored badge (green for active, red for inactive) for better visibility.