### PR TITLE
feat: Add OTP validation and Profile button

### DIFF
--- a/src/store/auth/authSlice.ts
+++ b/src/store/auth/authSlice.ts
@@ -73,8 +73,15 @@ const authSlice = createSlice({
     resetOtpSent(state) {
       state.otpSent = false;
     },
-    authCheckCompleted(state, action: PayloadAction<{ isAuthenticated: boolean }>) {
+    checkAuthStatusRequest(state) {
+      state.isAuthLoading = true;
+    },
+    setUser(state, action: PayloadAction<Account>) {
+      state.user = action.payload;
+    },
+    authCheckCompleted(state, action: PayloadAction<{ isAuthenticated: boolean, user?: Account | null }>) {
       state.isAuthenticated = action.payload.isAuthenticated;
+      state.user = action.payload.user || null;
       state.isAuthLoading = false;
     }
   },
@@ -89,6 +96,8 @@ export const {
     loginFailure,
     logout,
     resetOtpSent,
+    checkAuthStatusRequest,
+    setUser,
     authCheckCompleted,
 } = authSlice.actions;
 


### PR DESCRIPTION
This commit introduces two new features and fixes a related bug:

1.  **OTP Validation:** Added client-side validation to the login form. This prevents the login API call from being made if the OTP field is empty and displays an error message to the user.

2.  **Profile Button and User Fetching:**
    *   Added a "Profile" button to the user menu in the main dashboard shell. This button navigates the user to their own account edit page.
    *   Implemented a new saga to fetch the logged-in user's full profile data upon application load (after authentication is confirmed). This ensures the user's `accountId` is available in the Redux state, making the "Profile" button functional on page refresh.