### PR TITLE
fix: Resolve logout on refresh and implement profile button

### DIFF
--- a/src/store/auth/authSlice.ts
+++ b/src/store/auth/authSlice.ts
@@ -68,16 +68,11 @@ const authSlice = createSlice({
       state.phoneNumber = null;
       state.otpSent = false;
       localStorage.removeItem('token');
+      localStorage.removeItem('user');
       document.cookie = "token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
     },
     resetOtpSent(state) {
       state.otpSent = false;
-    },
-    checkAuthStatusRequest(state) {
-      state.isAuthLoading = true;
-    },
-    setUser(state, action: PayloadAction<Account>) {
-      state.user = action.payload;
     },
     authCheckCompleted(state, action: PayloadAction<{ isAuthenticated: boolean, user?: Account | null }>) {
       state.isAuthenticated = action.payload.isAuthenticated;
@@ -96,8 +91,6 @@ export const {
     loginFailure,
     logout,
     resetOtpSent,
-    checkAuthStatusRequest,
-    setUser,
     authCheckCompleted,
 } = authSlice.actions;
 


### PR DESCRIPTION
This commit fixes a critical bug that caused the user to be logged out upon refreshing the page. It also completes the implementation of the "Profile" button and adds OTP validation.

The main changes are:
1.  **Fix Logout on Refresh:** The root cause was a failed API call in a saga trying to fetch user data on load. This has been fixed by persisting the encrypted user object in `localStorage` upon login and rehydrating the state from there, removing the need for the failing API call.
2.  **Enable Profile Button:** With the user object now correctly populated on page load, the "Profile" button in the dashboard shell now functions as intended, navigating to the logged-in user's account edit page.
3.  **Add OTP Validation:** Added client-side validation to the login form to prevent submissions with an empty OTP field.