### PR TITLE
Fix: Resolve logout on refresh issue with robust auth rehydration

### DIFF
--- a/src/store/StoreProvider.tsx
+++ b/src/store/StoreProvider.tsx
@@ -19,32 +19,40 @@ function AuthRehydrator({ children }: { children: React.ReactNode }) {
     const encryptedToken = localStorage.getItem('token');
     const encryptedUser = localStorage.getItem('user');
 
-    if (encryptedToken) {
-      try {
+    try {
+      if (encryptedToken) {
+        // A token exists, so we expect a full, valid session.
+        if (!encryptedUser) {
+          throw new Error("Incomplete session: Token found but user data is missing.");
+        }
+
         const decryptedTokenBytes = CryptoJS.AES.decrypt(encryptedToken, secretPass);
         const decryptedToken = decryptedTokenBytes.toString(CryptoJS.enc.Utf8);
-
-        if (decryptedToken) {
-          const token = JSON.parse(decryptedToken);
-          axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${token}`;
-          isAuthenticated = true;
-
-          // If token is valid, try to load user data
-          if (encryptedUser) {
-            const decryptedUserBytes = CryptoJS.AES.decrypt(encryptedUser, secretPass);
-            const decryptedUser = decryptedUserBytes.toString(CryptoJS.enc.Utf8);
-            user = JSON.parse(decryptedUser);
-          }
+        if (!decryptedToken) {
+          throw new Error("Failed to decrypt token.");
         }
-      } catch (e) {
-        console.error("Failed to decrypt token or user on load, logging out.", e);
-        delete axiosInstance.defaults.headers.common['Authorization'];
-        localStorage.removeItem('token');
-        document.cookie = "token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
-        localStorage.removeItem('user'); // Also clear user
-        isAuthenticated = false;
-        user = null;
+        const token = JSON.parse(decryptedToken);
+
+        const decryptedUserBytes = CryptoJS.AES.decrypt(encryptedUser, secretPass);
+        const decryptedUser = decryptedUserBytes.toString(CryptoJS.enc.Utf8);
+        if (!decryptedUser) {
+          throw new Error("Failed to decrypt user data.");
+        }
+        const parsedUser = JSON.parse(decryptedUser);
+
+        // If we get here, everything is valid.
+        axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+        user = parsedUser;
+        isAuthenticated = true;
       }
+    } catch (e) {
+      console.error("Failed to rehydrate auth state, logging out.", e);
+      delete axiosInstance.defaults.headers.common['Authorization'];
+      localStorage.removeItem('token');
+      localStorage.removeItem('user');
+      document.cookie = "token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
+      isAuthenticated = false;
+      user = null;
     }
 
     dispatch(authCheckCompleted({ isAuthenticated, user }));


### PR DESCRIPTION
This commit fixes a critical bug that caused users to be logged out on page refresh. The issue was caused by a combination of a race condition and unhandled errors from corrupted session data.

The fix includes:
1.  **Robust Auth Rehydration:** The `AuthRehydrator` component in `StoreProvider.tsx` has been refactored to handle errors gracefully. It now validates the entire session (token and user data) from local storage. If any part is missing, corrupted, or fails to decrypt/parse, it catches the error, clears all authentication state (local storage, cookies, and headers), and logs the user out. This prevents application crashes from bad session data.

2.  **Race Condition Fix:** The `DashboardShell.tsx` component now uses an `isAuthLoading` flag from the Redux store. This ensures that the application waits for the authentication rehydration process to complete before checking the user's authentication status and potentially redirecting them to the login page.