### PR TITLE
Fix: Map account to user in login response

### DIFF
--- a/src/services/authService.tsx
+++ b/src/services/authService.tsx
@@ -6,7 +6,12 @@ const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 export const loginData = async (endpoint: string, payload: LoginPayload) => {
   try {
     const response = await axios.post(`${BASE_URL}${endpoint}`, payload);
-    return { result: response.data, msg: "success" };
+    const { account, ...rest } = response.data;
+    const result = {
+      ...rest,
+      user: account,
+    };
+    return { result, msg: "success" };
   } catch (error) {
     const axiosError = error as AxiosError<{ message: string }>;
     return { msg: axiosError.response?.data?.message || "Invalid Credentials" };


### PR DESCRIPTION
The login API response returns an `account` object, but the frontend application expects a `user` object. This mismatch causes login to fail to store user data correctly.

This commit modifies the `loginData` function in `authService.tsx` to transform the API response. It maps the `account` field to a `user` field, ensuring the data structure aligns with the `AuthResponse` type and the rest of the application.