### PR TITLE
Refactor: Move login data mapping to saga

### DIFF
--- a/src/services/authService.tsx
+++ b/src/services/authService.tsx
@@ -6,12 +6,7 @@ const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 export const loginData = async (endpoint: string, payload: LoginPayload) => {
   try {
     const response = await axios.post(`${BASE_URL}${endpoint}`, payload);
-    const { account, ...rest } = response.data;
-    const result = {
-      ...rest,
-      user: account,
-    };
-    return { result, msg: "success" };
+    return { result: response.data, msg: "success" };
   } catch (error) {
     const axiosError = error as AxiosError<{ message: string }>;
     return { msg: axiosError.response?.data?.message || "Invalid Credentials" };

--- a/src/store/auth/authSaga.ts
+++ b/src/store/auth/authSaga.ts
@@ -10,6 +10,7 @@ import {
 } from './authSlice';
 import { setAuthToken } from '@/services/apiHelper';
 import { AuthResponse, SendOtpResponse } from '@/types/auth';
+import { Account, AccountType } from '@/types/entities';
 import CryptoJS from 'crypto-js';
 
 function* handleSendOtp(action: ReturnType<typeof sendOtpRequest>) {
@@ -32,15 +33,38 @@ const secretPass = 'al123@st678$ven';
 function* handleLogin(action: ReturnType<typeof loginRequest>) {
     const { phoneNumber, otp, country_code } = action.payload;
   try {
-    const response: AuthResponse = yield call(loginData, '/api/verify-otp', { phone: phoneNumber, otp, country_code });
+    // The response from loginData will be raw from the API.
+    // We need to cast it to 'any' to access the 'account' property,
+    // as AuthResponse expects a 'user' property.
+    const response: any = yield call(loginData, '/api/verify-otp', { phone: phoneNumber, otp, country_code });
     if (response.msg === 'success' && response.result?.token) {
       setAuthToken(response.result.token);
 
+      const { account } = response.result;
+
+      // Manually map the account data from the API to the application's Account type.
+      const user: Account = {
+        accountId: account.id.toString(),
+        firstName: account.first_name,
+        lastName: account.last_name,
+        emailAddress: account.email,
+        phoneNumber: account.phone,
+        country_code: account.country_code,
+        accountType: account.account_type as AccountType,
+        signUpDate: account.created_at,
+        status: account.status as "active" | "inactive",
+        avatarInitials: `${account.first_name.charAt(0)}${account.last_name.charAt(0)}`,
+        avatarBackground: '#000000', // Default background color
+        subscriptionCount: 0,
+        brandsCount: 0,
+        campaignsCount: 0,
+      };
+
       // Encrypt and store user data
-      const encryptedUser = CryptoJS.AES.encrypt(JSON.stringify(response.result.user), secretPass).toString();
+      const encryptedUser = CryptoJS.AES.encrypt(JSON.stringify(user), secretPass).toString();
       localStorage.setItem('user', encryptedUser);
 
-      yield put(loginSuccess(response.result.user));
+      yield put(loginSuccess(user));
     } else {
       yield put(loginFailure(response.msg || 'Login failed'));
     }


### PR DESCRIPTION
Per user request, the data transformation logic for the login response has been moved from the service layer (`authService.tsx`) to the saga (`authSaga.ts`).

The `handleLogin` saga now intercepts the raw API response and performs a comprehensive transformation. This includes:
- Mapping the `account` object to a `user` object.
- Converting `snake_case` property names to `camelCase`.
- Renaming fields to match the application's `Account` type.
- Providing default values for properties not present in the API response.

This change ensures the data is correctly formatted before being passed to the Redux store, while centralizing the logic in the saga as requested.