### PR TITLE
Fix: Resolve build error in login saga by replacing 'any' type

### DIFF
--- a/src/services/authService.tsx
+++ b/src/services/authService.tsx
@@ -1,11 +1,11 @@
 import axios, { AxiosError } from 'axios';
-import { LoginPayload, SendOtpPayload } from '@/types/auth';
+import { ApiAuthResponse, ApiLoginResult, LoginPayload, SendOtpPayload } from '@/types/auth';
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
-export const loginData = async (endpoint: string, payload: LoginPayload) => {
+export const loginData = async (endpoint: string, payload: LoginPayload): Promise<ApiAuthResponse> => {
   try {
-    const response = await axios.post(`${BASE_URL}${endpoint}`, payload);
+    const response = await axios.post<ApiLoginResult>(`${BASE_URL}${endpoint}`, payload);
     return { result: response.data, msg: "success" };
   } catch (error) {
     const axiosError = error as AxiosError<{ message: string }>;

--- a/src/store/auth/authSaga.ts
+++ b/src/store/auth/authSaga.ts
@@ -9,7 +9,7 @@ import {
   loginFailure
 } from './authSlice';
 import { setAuthToken } from '@/services/apiHelper';
-import { AuthResponse, SendOtpResponse } from '@/types/auth';
+import { ApiAuthResponse, SendOtpResponse } from '@/types/auth';
 import { Account, AccountType } from '@/types/entities';
 import CryptoJS from 'crypto-js';
 
@@ -33,10 +33,7 @@ const secretPass = 'al123@st678$ven';
 function* handleLogin(action: ReturnType<typeof loginRequest>) {
     const { phoneNumber, otp, country_code } = action.payload;
   try {
-    // The response from loginData will be raw from the API.
-    // We need to cast it to 'any' to access the 'account' property,
-    // as AuthResponse expects a 'user' property.
-    const response: any = yield call(loginData, '/api/verify-otp', { phone: phoneNumber, otp, country_code });
+    const response: ApiAuthResponse = yield call(loginData, '/api/verify-otp', { phone: phoneNumber, otp, country_code });
     if (response.msg === 'success' && response.result?.token) {
       setAuthToken(response.result.token);
 

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -23,3 +23,32 @@ export interface LoginPayload {
     msg: string;
     result?: unknown;
   }
+
+  /**
+   * Represents the raw account object from the API response.
+   */
+  interface ApiAccount {
+    id: number;
+    first_name: string;
+    last_name: string;
+    email: string;
+    phone: string;
+    country_code: string;
+    account_type: string;
+    registration_type: string;
+    status: string;
+    created_at: string;
+    updated_at: string;
+    deleted_at: string | null;
+  }
+
+  /**
+   * Represents the raw response from the login API.
+   */
+  export interface ApiAuthResponse {
+    msg: string;
+    result?: {
+      token: string;
+      account: ApiAccount;
+    };
+  }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -43,12 +43,17 @@ export interface LoginPayload {
   }
 
   /**
-   * Represents the raw response from the login API.
+   * Represents the shape of the `result` object from the login API response.
+   */
+  export interface ApiLoginResult {
+    token: string;
+    account: ApiAccount;
+  }
+
+  /**
+   * Represents the raw response from the login API, as returned by the auth service.
    */
   export interface ApiAuthResponse {
     msg: string;
-    result?: {
-      token: string;
-      account: ApiAccount;
-    };
+    result?: ApiLoginResult;
   }


### PR DESCRIPTION
The previous implementation in the login saga used the `any` type for the API response, which caused a build error, likely due to strict linting rules.

This commit resolves the build error by introducing a specific type, `ApiAuthResponse`, which accurately models the raw API response structure, including the `account` object with `snake_case` keys.

The `handleLogin` saga in `src/store/auth/authSaga.ts` has been updated to use this new type, making the code more type-safe and compliant with the project's coding standards.