### PR TITLE
feat: Improve UI and UX of add/edit forms

### DIFF
--- a/src/app/(features)/businesses/accounts/[accountId]/page.tsx
+++ b/src/app/(features)/businesses/accounts/[accountId]/page.tsx
@@ -132,6 +132,7 @@ export default function AccountPage() {
           activeTab={activeTab}
           account={account}
           onSave={handleSave}
+          isCreateMode={isCreateMode}
         />
       </div>
     </div>

--- a/src/app/(features)/businesses/brands/[brandId]/page.tsx
+++ b/src/app/(features)/businesses/brands/[brandId]/page.tsx
@@ -95,6 +95,7 @@ export default function BrandPage() {
             isEditMode: true,
             onSave: handleSave,
             isSaving: isSaving,
+            isCreateMode: isCreateMode,
           }}
         />
       </div>

--- a/src/components/features/accounts/AccountDetails.tsx
+++ b/src/components/features/accounts/AccountDetails.tsx
@@ -53,9 +53,10 @@ const InputField = ({
 interface AccountDetailsProps {
   account: Partial<Account> | null;
   onSave: (account: Partial<Account>) => void;
+  isCreateMode: boolean;
 }
 
-export default function AccountDetails({ account, onSave }: AccountDetailsProps) {
+export default function AccountDetails({ account, onSave, isCreateMode }: AccountDetailsProps) {
   const [formData, setFormData] = useState<Partial<Account>>(
     account || {
       firstName: "",
@@ -199,7 +200,7 @@ export default function AccountDetails({ account, onSave }: AccountDetailsProps)
             initialSelectedBrands={formData.brands || []}
             onChange={handleBrandChange}
           />
-          <div className="flex justify-end gap-4 mt-6 flex-shrink-0 mb-4 md:mb-0">
+          <div className="flex justify-end gap-4 mt-6 px-4 pb-6">
             <button
               type="button"
               onClick={() => router.back()}
@@ -211,7 +212,7 @@ export default function AccountDetails({ account, onSave }: AccountDetailsProps)
               type="submit"
               className="px-6 py-2 text-sm font-semibold text-white bg-blue-600 rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
             >
-              Save Account
+              {isCreateMode ? "Save" : "Save Changes"}
             </button>
           </div>
         </div>

--- a/src/components/features/accounts/AccountTabContent.tsx
+++ b/src/components/features/accounts/AccountTabContent.tsx
@@ -7,17 +7,19 @@ import { Account } from "@/types/entities";
 interface AccountTabContentProps extends TabContentProps {
   account: Partial<Account> | null;
   onSave: (account: Partial<Account>) => void;
+  isCreateMode: boolean;
 }
 
 export default function AccountTabContent({
   activeTab,
   account,
   onSave,
+  isCreateMode,
 }: AccountTabContentProps) {
   const renderContent = () => {
     switch (activeTab) {
       case "Details":
-        return <AccountDetails account={account} onSave={onSave} />;
+        return <AccountDetails account={account} onSave={onSave} isCreateMode={isCreateMode} />;
       case "Brands":
         return (
           <div className="max-w-[1428px] mx-auto flex justify-between pt-10 text-[#4F4F4F]">

--- a/src/components/features/brands/BrandDetails.tsx
+++ b/src/components/features/brands/BrandDetails.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { Brand } from "@/types/entities";
 import SearchableDropdown from "@/components/general/dropdowns/SearchableDropdown";
@@ -15,6 +16,7 @@ interface BrandDetailsProps {
   onFileChange: (field: keyof Brand, file: File) => void;
   onSave: () => void;
   isSaving: boolean;
+  isCreateMode: boolean;
 }
 
 interface IconProps {
@@ -76,7 +78,9 @@ export default function BrandDetails({
   onFileChange,
   onSave,
   isSaving,
+  isCreateMode,
 }: BrandDetailsProps) {
+  const router = useRouter();
   const dispatch = useDispatch();
   const { countries, states, industries, loading, error } = useSelector(
     (state: RootState) => state.common
@@ -315,13 +319,20 @@ export default function BrandDetails({
               </div>
             </div>
           </div>
-          <div className="flex justify-end mt-4 px-4 pb-6">
+          <div className="flex justify-end gap-4 mt-4 px-4 pb-6">
+            <button
+              type="button"
+              onClick={() => router.back()}
+              className="px-6 py-2 text-sm font-semibold text-gray-700 bg-gray-200 rounded-lg hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+            >
+              Cancel
+            </button>
             <button
               onClick={onSave}
               disabled={isSaving}
               className="bg-blue-500 text-white rounded-[11px] text-[18px] leading-[27px] pt-1.25 pb-1.75 px-6"
             >
-              {isSaving ? "Saving..." : "Save Changes"}
+              {isSaving ? "Saving..." : isCreateMode ? "Save" : "Save Changes"}
             </button>
           </div>
         </div>

--- a/src/components/features/brands/BrandTabContent.tsx
+++ b/src/components/features/brands/BrandTabContent.tsx
@@ -11,6 +11,7 @@ interface BrandTabContentProps extends TabContentProps {
     onFileChange: (field: keyof Brand, file: File) => void;
     onSave: () => void;
     isSaving: boolean;
+    isCreateMode: boolean;
   };
 }
 
@@ -32,6 +33,7 @@ export default function BrandTabContent({
             onFileChange={brand.onFileChange}
             onSave={brand.onSave}
             isSaving={brand.isSaving}
+            isCreateMode={brand.isCreateMode}
           />
         );
       case "Campaigns":


### PR DESCRIPTION
This commit introduces several UI and UX improvements to the add/edit forms for both accounts and brands.

- The save button text is now dynamic, displaying "Save" in create mode and "Save Changes" in edit mode.
- A "Cancel" button has been added to the brands form to provide a consistent user experience.
- The spacing below the buttons in the accounts form has been adjusted to match the styling of the brands form.

These changes create a more intuitive and consistent experience for users when managing accounts and brands.