### PR TITLE
feat: Add account selection dropdown to brand form

### DIFF
--- a/src/components/features/brands/BrandDetails.tsx
+++ b/src/components/features/brands/BrandDetails.tsx
@@ -7,7 +7,7 @@ import SearchableDropdown from "@/components/general/dropdowns/SearchableDropdow
 import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "@/store/store";
-import { fetchCountries, fetchIndustries, fetchStates } from "@/store/common/commonSlice";
+import { fetchAllAccounts, fetchCountries, fetchIndustries, fetchStates } from "@/store/common/commonSlice";
 
 interface BrandDetailsProps {
   brand: Partial<Brand>;
@@ -82,13 +82,14 @@ export default function BrandDetails({
 }: BrandDetailsProps) {
   const router = useRouter();
   const dispatch = useDispatch();
-  const { countries, states, industries, loading, error } = useSelector(
+  const { countries, states, industries, allAccounts, loading, error } = useSelector(
     (state: RootState) => state.common
   );
 
   useEffect(() => {
     dispatch(fetchCountries());
     dispatch(fetchIndustries());
+    dispatch(fetchAllAccounts());
   }, [dispatch]);
 
   useEffect(() => {
@@ -111,6 +112,21 @@ export default function BrandDetails({
                 Business Details
               </h3>
               <div className="px-4 ">
+                <div className="mb-5 md:mb-7">
+                  <label
+                    htmlFor="account"
+                    className="block text-[#4F4F4F] mb-2.5 truncate"
+                  >
+                    Account
+                  </label>
+                  <SearchableDropdown
+                    options={allAccounts}
+                    selectedValue={brand.accountId || ""}
+                    onValueChange={(value) => onFieldChange("accountId", value)}
+                    placeholder="Select an account"
+                    disabled={loading.allAccounts}
+                  />
+                </div>
                 <div className="mb-5 md:mb-7">
                   <InputField
                     label="Business name"

--- a/src/store/common/commonSaga.ts
+++ b/src/store/common/commonSaga.ts
@@ -10,6 +10,9 @@ import {
   fetchIndustries,
   fetchIndustriesSuccess,
   fetchIndustriesFailure,
+  fetchAllAccounts,
+  fetchAllAccountsSuccess,
+  fetchAllAccountsFailure,
 } from "./commonSlice";
 import { PayloadAction } from "@reduxjs/toolkit";
 import { Option } from "@/types/common";
@@ -66,10 +69,28 @@ function* fetchIndustriesSaga() {
   }
 }
 
+function* fetchAllAccountsSaga() {
+  try {
+    const response: any = yield call(fetchData, "/api/all/accounts");
+    if (response && response.accounts) {
+      const formattedData: Option[] = response.accounts.map((account: any) => ({
+        value: account.id.toString(),
+        label: `${account.first_name} ${account.last_name}`,
+      }));
+      yield put(fetchAllAccountsSuccess(formattedData));
+    } else {
+      yield put(fetchAllAccountsFailure(response.message || "Failed to fetch accounts"));
+    }
+  } catch (error: any) {
+    yield put(fetchAllAccountsFailure(error.message));
+  }
+}
+
 function* commonSaga() {
   yield takeLatest(fetchCountries.type, fetchCountriesSaga);
   yield takeLatest(fetchStates.type, fetchStatesSaga);
   yield takeLatest(fetchIndustries.type, fetchIndustriesSaga);
+  yield takeLatest(fetchAllAccounts.type, fetchAllAccountsSaga);
 }
 
 export default commonSaga;

--- a/src/store/common/commonSlice.ts
+++ b/src/store/common/commonSlice.ts
@@ -5,15 +5,18 @@ interface CommonState {
   countries: Option[];
   states: Option[];
   industries: Option[];
+  allAccounts: Option[];
   loading: {
     countries: boolean;
     states: boolean;
     industries: boolean;
+    allAccounts: boolean;
   };
   error: {
     countries: string | null;
     states: string | null;
     industries: string | null;
+    allAccounts: string | null;
   };
 }
 
@@ -21,15 +24,18 @@ const initialState: CommonState = {
   countries: [],
   states: [],
   industries: [],
+  allAccounts: [],
   loading: {
     countries: false,
     states: false,
     industries: false,
+    allAccounts: false,
   },
   error: {
     countries: null,
     states: null,
     industries: null,
+    allAccounts: null,
   },
 };
 
@@ -73,6 +79,18 @@ const commonSlice = createSlice({
       state.error.industries = action.payload;
       state.loading.industries = false;
     },
+    fetchAllAccounts: (state) => {
+      state.loading.allAccounts = true;
+      state.error.allAccounts = null;
+    },
+    fetchAllAccountsSuccess: (state, action: PayloadAction<Option[]>) => {
+      state.allAccounts = action.payload;
+      state.loading.allAccounts = false;
+    },
+    fetchAllAccountsFailure: (state, action: PayloadAction<string>) => {
+      state.error.allAccounts = action.payload;
+      state.loading.allAccounts = false;
+    },
   },
 });
 
@@ -86,6 +104,9 @@ export const {
   fetchIndustries,
   fetchIndustriesSuccess,
   fetchIndustriesFailure,
+  fetchAllAccounts,
+  fetchAllAccountsSuccess,
+  fetchAllAccountsFailure,
 } = commonSlice.actions;
 
 export default commonSlice.reducer;


### PR DESCRIPTION
This commit introduces a new feature to the brand add/edit form: a searchable dropdown to select an account.

- The Redux store has been updated to fetch a list of all accounts from the `/api/all/accounts` endpoint.
- A new `SearchableDropdown` component has been added to the brand form, allowing users to associate a brand with an existing account.
- The dropdown displays the full name of the account holder and stores the account ID.

This change improves the workflow for managing brands by allowing them to be easily associated with the correct account upon creation or update.