### PR TITLE
feat: Reorder account dropdown in brand form

### DIFF
--- a/src/components/features/brands/BrandDetails.tsx
+++ b/src/components/features/brands/BrandDetails.tsx
@@ -113,21 +113,6 @@ export default function BrandDetails({
               </h3>
               <div className="px-4 ">
                 <div className="mb-5 md:mb-7">
-                  <label
-                    htmlFor="account"
-                    className="block text-[#4F4F4F] mb-2.5 truncate"
-                  >
-                    Account
-                  </label>
-                  <SearchableDropdown
-                    options={allAccounts}
-                    selectedValue={brand.accountId || ""}
-                    onValueChange={(value) => onFieldChange("accountId", value)}
-                    placeholder="Select an account"
-                    disabled={loading.allAccounts}
-                  />
-                </div>
-                <div className="mb-5 md:mb-7">
                   <InputField
                     label="Business name"
                     value={brand.name || ""}
@@ -155,6 +140,21 @@ export default function BrandDetails({
                       height: 16.26,
                       alt: "copy",
                     }}
+                  />
+                </div>
+                <div className="mb-5 md:mb-7">
+                  <label
+                    htmlFor="account"
+                    className="block text-[#4F4F4F] mb-2.5 truncate"
+                  >
+                    Account
+                  </label>
+                  <SearchableDropdown
+                    options={allAccounts}
+                    selectedValue={brand.accountId || ""}
+                    onValueChange={(value) => onFieldChange("accountId", value)}
+                    placeholder="Select an account"
+                    disabled={loading.allAccounts}
                   />
                 </div>
                 <div className="grid grid-cols-2 gap-5 mb-5 md:mb-7">


### PR DESCRIPTION
This commit reorders the fields in the brand add/edit form to place the "Account" dropdown after the "Company Name" field, as requested by the user.

This change improves the logical flow of the form.

This commit is part of a larger set of enhancements to the brand and account forms.