### PR TITLE
feat: Add brands list feature

### DIFF
--- a/src/components/features/brands/BrandsTable.tsx
+++ b/src/components/features/brands/BrandsTable.tsx
@@ -140,9 +140,19 @@ export default function BrandsTable({
                 {brand.profileCompletion}%
               </td> */}
               <td className="px-6 py-2.5 whitespace-nowrap text-[15px] text-[#4F4F4F] text-center">
-                <button className="bg-blue-500 text-white rounded-[11px] text-[15px] px-4 py-1">
-                  View Files
-                </button>
+                <div className="flex items-center justify-center cursor-pointer">
+                  <Image
+                    alt="Upload"
+                    loading="lazy"
+                    width="13.14"
+                    height="16.97"
+                    decoding="async"
+                    data-nimg="1"
+                    src="/icons/general/upload-1.svg"
+                    style={{ color: "transparent" }}
+                  />
+                  <span className="ml-2">Upload</span>
+                </div>
               </td>
             </tr>
           ))}

--- a/src/store/brand/brandSaga.ts
+++ b/src/store/brand/brandSaga.ts
@@ -17,11 +17,15 @@ interface ApiBrand {
   venue_url: string;
   venue_whatsapp_no: string;
   venue_email: string;
+  venue_logo: string;
   venue_banner: string;
   created_at: string;
+  category: {
+    id: number;
+    category: string;
+  };
   // Assuming the following fields are available in the API response
   owner?: string;
-  industry?: string;
   offers_count?: number;
   profile_completion?: number;
   files_count?: number;
@@ -60,11 +64,11 @@ function* handleFetchBrands(action: ReturnType<typeof fetchBrandsRequest>) {
         brandId: apiBrand.id.toString(),
         name: apiBrand.venue_title,
         owner: apiBrand.owner || 'N/A',
-        logo: apiBrand.venue_banner,
+        logo: apiBrand.venue_logo,
         websiteUrl: apiBrand.venue_url,
         phoneNumber: apiBrand.venue_whatsapp_no,
         emailAddress: apiBrand.venue_email,
-        industry: apiBrand.industry || 'N/A',
+        industry: apiBrand.category?.category || 'N/A',
         registrationDate: apiBrand.created_at,
         offersCount: apiBrand.offers_count || 0,
         campaignsCount: 0, // This should be updated with actual data if available
@@ -128,11 +132,11 @@ function* handleFetchMoreBrands(action: ReturnType<typeof fetchMoreBrandsRequest
         brandId: apiBrand.id.toString(),
         name: apiBrand.venue_title,
         owner: apiBrand.owner || 'N/A',
-        logo: apiBrand.venue_banner,
+        logo: apiBrand.venue_logo,
         websiteUrl: apiBrand.venue_url,
         phoneNumber: apiBrand.venue_whatsapp_no,
         emailAddress: apiBrand.venue_email,
-        industry: apiBrand.industry || 'N/A',
+        industry: apiBrand.category?.category || 'N/A',
         registrationDate: apiBrand.created_at,
         offersCount: apiBrand.offers_count || 0,
         campaignsCount: 0, // This should be updated with actual data if available


### PR DESCRIPTION
This commit introduces a new feature that displays a list of brands. The feature includes a paginated table view for desktop and a card-based view for mobile, with a 'See More' button for loading additional brands. The implementation follows the existing pattern for the 'accounts' list, with a new Redux slice and saga for managing brand data.