### PR TITLE
feat: Add brands list feature

### DIFF
--- a/src/components/features/brands/BrandsTable.tsx
+++ b/src/components/features/brands/BrandsTable.tsx
@@ -139,20 +139,20 @@ export default function BrandsTable({
               {/* <td className="px-6 py-2.5 whitespace-nowrap text-[15px] text-[#4F4F4F] text-center">
                 {brand.profileCompletion}%
               </td> */}
-              <td className="px-6 py-2.5 whitespace-nowrap text-[15px] text-[#4F4F4F] text-center">
-                <div className="flex items-center justify-center cursor-pointer">
+              <td className="px-4 py-[8.5px] whitespace-nowrap text-center text-[#4F4F4F]">
+                <button className="bg-[#636363] text-white flex items-center justify-center gap-2.5 px-4 py-1.5 rounded-full text-[13px]">
                   <Image
-                    alt="Upload"
+                    alt="download"
                     loading="lazy"
-                    width="13.14"
-                    height="16.97"
+                    width="13.15"
+                    height="16.99"
                     decoding="async"
                     data-nimg="1"
                     src="/icons/general/upload-1.svg"
                     style={{ color: "transparent" }}
                   />
-                  <span className="ml-2">Upload</span>
-                </div>
+                  <span className="ml-1">Upload</span>
+                </button>
               </td>
             </tr>
           ))}


### PR DESCRIPTION
This commit introduces a new feature that displays a list of brands. The feature includes a paginated table view for desktop and a card-based view for mobile, with a 'See More' button for loading additional brands. The implementation follows the existing pattern for the 'accounts' list, with a new Redux slice and saga for managing brand data.