### PR TITLE
feat: Implement Add Venue with Redux Saga

### DIFF
--- a/src/store/brand/brandSaga.ts
+++ b/src/store/brand/brandSaga.ts
@@ -8,6 +8,9 @@ import {
   fetchMoreBrandsRequest,
   fetchMoreBrandsSuccess,
   fetchMoreBrandsFailure,
+  createBrandRequest,
+  createBrandSuccess,
+  createBrandFailure,
 } from './brandSlice';
 import { Brand } from '@/types/entities';
 
@@ -183,9 +186,51 @@ function* handleFetchMoreBrands(action: ReturnType<typeof fetchMoreBrandsRequest
   }
 }
 
+function* handleCreateBrand(action: ReturnType<typeof createBrandRequest>) {
+  try {
+    const brand = action.payload;
+    const formData = new FormData();
+    formData.append('venue_title', brand.name || '');
+    formData.append('company_name', brand.companyName || '');
+    formData.append('account_id', brand.accountId || '');
+    formData.append('country_id', brand.country || '');
+    formData.append('state_id', brand.state || '');
+    formData.append('category_id', brand.industry || '');
+    formData.append('venue_instagram_url', brand.instagramHandle || '');
+    formData.append('venue_url', brand.websiteUrl || '');
+    formData.append('Venue_contact_name', brand.associateName || '');
+    formData.append('venue_email', brand.associateEmail || '');
+    formData.append('venue_contact_number', brand.associatePhone || '');
+
+    if (brand.tradeLicenseCopy) {
+      formData.append('trade_license_file', brand.tradeLicenseCopy);
+    }
+    if (brand.vatCertificate) {
+      formData.append('vat_certificate_file', brand.vatCertificate);
+    }
+
+    const response: { message: string } | ApiError = yield call(postData, '/api/add/venue', formData);
+
+    if ('message' in response) {
+      yield put(createBrandSuccess());
+      toast.success(response.message);
+    } else {
+      const errorMessage = response.response || 'Failed to create brand';
+      yield put(createBrandFailure(errorMessage));
+      toast.error(errorMessage);
+    }
+  } catch (error) {
+    const err = error as Error;
+    const errorMessage = err.message || 'An unknown error occurred';
+    yield put(createBrandFailure(errorMessage));
+    toast.error(errorMessage);
+  }
+}
+
 function* watchBrand() {
   yield takeLatest(fetchBrandsRequest.type, handleFetchBrands);
   yield takeLatest(fetchMoreBrandsRequest.type, handleFetchMoreBrands);
+  yield takeLatest(createBrandRequest.type, handleCreateBrand);
 }
 
 export default function* brandSaga() {

--- a/src/store/brand/brandSlice.ts
+++ b/src/store/brand/brandSlice.ts
@@ -7,6 +7,8 @@ interface BrandState {
   pagination: PaginationState;
   loading: boolean;
   error: string | null;
+  createLoading: boolean;
+  createSuccess: boolean;
 }
 
 const initialState: BrandState = {
@@ -19,6 +21,8 @@ const initialState: BrandState = {
   },
   loading: false,
   error: null,
+  createLoading: false,
+  createSuccess: false,
 };
 
 const brandSlice = createSlice({
@@ -51,6 +55,19 @@ const brandSlice = createSlice({
       state.loading = false;
       state.error = action.payload;
     },
+    createBrandRequest: (state, action: PayloadAction<Partial<Brand>>) => {
+      state.createLoading = true;
+      state.createSuccess = false;
+      state.error = null;
+    },
+    createBrandSuccess: (state) => {
+      state.createLoading = false;
+      state.createSuccess = true;
+    },
+    createBrandFailure: (state, action: PayloadAction<string>) => {
+      state.createLoading = false;
+      state.error = action.payload;
+    },
   },
 });
 
@@ -61,6 +78,9 @@ export const {
   fetchMoreBrandsRequest,
   fetchMoreBrandsSuccess,
   fetchMoreBrandsFailure,
+  createBrandRequest,
+  createBrandSuccess,
+  createBrandFailure,
 } = brandSlice.actions;
 
 export default brandSlice.reducer;


### PR DESCRIPTION
This commit refactors the 'Add Brand' feature to use Redux Saga for handling the API call to `/api/add/venue`. This aligns the implementation with the existing architecture of the application.

Changes:
- Moved the API call logic from the component to a new worker saga in `brandSaga.ts`.
- Added `createBrand` actions and state to the `brandSlice`.
- Connected the `BrandPage` component to Redux to dispatch the create action and listen for success/loading states.
- Maintained the inline validation and toast notification functionality.