### PR TITLE
feat: Implement Add Venue with Redux, validation, and fixes

### DIFF
--- a/src/app/(features)/businesses/brands/[brandId]/page.tsx
+++ b/src/app/(features)/businesses/brands/[brandId]/page.tsx
@@ -9,7 +9,7 @@ import BrandHeader from "@/components/features/brands/BrandHeader";
 import Loader from "@/components/general/Loader";
 import { fetchData } from "@/services/commonService";
 import { transformApiVenueToBrand } from "@/utils/brandUtils";
-import { createBrandRequest } from "@/store/brand/brandSlice";
+import { createBrandRequest, resetCreateStatus } from "@/store/brand/brandSlice";
 import { RootState } from "@/store/store";
 
 export default function BrandPage() {
@@ -51,8 +51,9 @@ export default function BrandPage() {
   useEffect(() => {
     if (createSuccess) {
       router.push("/businesses/brands");
+      dispatch(resetCreateStatus());
     }
-  }, [createSuccess, router]);
+  }, [createSuccess, router, dispatch]);
 
   const handleFieldChange = (field: keyof Brand, value: string) => {
     setBrand((prev) => ({ ...prev, [field]: value }));

--- a/src/components/features/brands/BrandDetails.tsx
+++ b/src/components/features/brands/BrandDetails.tsx
@@ -233,6 +233,7 @@ export default function BrandDetails({
                         type="file"
                         id="tradeLicenseCopy"
                         name="tradeLicenseCopy"
+                        accept=".pdf"
                         disabled={!isEditMode}
                         onChange={(e) => e.target.files && onFileChange("tradeLicenseCopy", e.target.files[0])}
                         className="w-full text-sm text-gray-900 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 focus:outline-none"
@@ -255,6 +256,7 @@ export default function BrandDetails({
                         type="file"
                         id="vatCertificate"
                         name="vatCertificate"
+                        accept=".pdf"
                         disabled={!isEditMode}
                         onChange={(e) => e.target.files && onFileChange("vatCertificate", e.target.files[0])}
                         className="w-full text-sm text-gray-900 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 focus:outline-none"

--- a/src/store/brand/brandSaga.ts
+++ b/src/store/brand/brandSaga.ts
@@ -32,6 +32,7 @@ interface ApiBrand {
   offers_count?: number;
   profile_completion?: number;
   files_count?: number;
+  accounts?: { first_name: string; last_name: string }[];
 }
 
 type ApiError = {
@@ -66,7 +67,7 @@ function* handleFetchBrands(action: ReturnType<typeof fetchBrandsRequest>) {
       const feBrands: Brand[] = data.map((apiBrand: ApiBrand) => ({
         brandId: apiBrand.id.toString(),
         name: apiBrand.venue_title,
-        owner: apiBrand.owner || 'N/A',
+        owner: apiBrand.accounts && apiBrand.accounts.length > 0 ? `${apiBrand.accounts[0].first_name} ${apiBrand.accounts[0].last_name}` : 'N/A',
         logo: apiBrand.venue_logo,
         websiteUrl: apiBrand.venue_url,
         phoneNumber: apiBrand.venue_whatsapp_no,
@@ -134,7 +135,7 @@ function* handleFetchMoreBrands(action: ReturnType<typeof fetchMoreBrandsRequest
       const feBrands: Brand[] = data.map((apiBrand: ApiBrand) => ({
         brandId: apiBrand.id.toString(),
         name: apiBrand.venue_title,
-        owner: apiBrand.owner || 'N/A',
+        owner: apiBrand.accounts && apiBrand.accounts.length > 0 ? `${apiBrand.accounts[0].first_name} ${apiBrand.accounts[0].last_name}` : 'N/A',
         logo: apiBrand.venue_logo,
         websiteUrl: apiBrand.venue_url,
         phoneNumber: apiBrand.venue_whatsapp_no,

--- a/src/store/brand/brandSlice.ts
+++ b/src/store/brand/brandSlice.ts
@@ -68,6 +68,10 @@ const brandSlice = createSlice({
       state.createLoading = false;
       state.error = action.payload;
     },
+    resetCreateStatus: (state) => {
+      state.createSuccess = false;
+      state.error = null;
+    },
   },
 });
 
@@ -81,6 +85,7 @@ export const {
   createBrandRequest,
   createBrandSuccess,
   createBrandFailure,
+  resetCreateStatus,
 } = brandSlice.actions;
 
 export default brandSlice.reducer;


### PR DESCRIPTION
This commit implements the full 'Add Venue' functionality by modifying the existing 'Add Brand' feature. It uses Redux Saga for API calls, includes inline validation, and addresses several user-requested fixes.

Changes:
- Integrated the `/api/add/venue` endpoint via a new Redux Saga.
- Added `createBrand` actions and state to the `brandSlice`.
- Implemented inline form validation in the component before dispatching the Redux action.
- Added success and error toast notifications handled by the saga.
- Restricted file uploads to PDF format.
- Fixed a navigation bug by resetting the Redux state after a successful creation.
- Correctly constructed the owner's full name from the API response for the brand list.