### PR TITLE
feat: Implement card view with lazy loading and bind data to edit form

### DIFF
--- a/src/app/(features)/businesses/brands/page.tsx
+++ b/src/app/(features)/businesses/brands/page.tsx
@@ -8,7 +8,7 @@ import { fetchBrandsRequest, fetchMoreBrandsRequest } from "@/store/brand/brandS
 import { setSearchTerm } from "@/store/search/searchSlice";
 import { RootState } from "@/store/store";
 import BrandsTable from "@/components/features/brands/BrandsTable";
-import BrandMobileCard from "@/components/features/brands/BrandMobileCard";
+import BrandCard from "@/components/features/brands/BrandCard";
 import Pagination from "@/components/general/Pagination";
 import ActionDropdown from "@/components/general/dropdowns/ActionDropdown";
 import SearchInputMobile from "@/components/general/SearchInputMobile";
@@ -100,6 +100,23 @@ export default function BrandsPage() {
     setMobilePage(nextPage);
   };
 
+  useEffect(() => {
+    const handleScroll = () => {
+      if (
+        window.innerHeight + document.documentElement.scrollTop >=
+          document.documentElement.offsetHeight - 500 &&
+        !loading &&
+        pagination &&
+        brands.length < pagination.total
+      ) {
+        handleSeeMore();
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [loading, pagination, brands, handleSeeMore]);
+
   return (
     <div>
       <div className="flex justify-between items-center pt-4">
@@ -170,11 +187,9 @@ export default function BrandsPage() {
                 ) : (
                   <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
                     {brands.map((brand) => (
-                      <BrandMobileCard
+                      <BrandCard
                         key={brand.brandId}
                         brand={brand}
-                        checked={checkedRows.has(brand.brandId)}
-                        onCheckboxChange={() => handleCheckboxChange(brand.brandId)}
                       />
                     ))}
                   </div>
@@ -191,11 +206,9 @@ export default function BrandsPage() {
               </div>
               <div className="md:hidden space-y-[7px]">
                 {brands.map((brand) => (
-                  <BrandMobileCard
+                  <BrandCard
                     key={brand.brandId}
                     brand={brand}
-                    checked={checkedRows.has(brand.brandId)}
-                    onCheckboxChange={() => handleCheckboxChange(brand.brandId)}
                   />
                 ))}
                 {pagination && brands.length < pagination.total && (

--- a/src/store/brand/brandSlice.ts
+++ b/src/store/brand/brandSlice.ts
@@ -4,6 +4,7 @@ import { PaginationState } from '@/types/api';
 
 interface BrandState {
   brands: Brand[];
+  brand: Brand | null;
   pagination: PaginationState;
   loading: boolean;
   error: string | null;
@@ -13,6 +14,7 @@ interface BrandState {
 
 const initialState: BrandState = {
   brands: [],
+  brand: null,
   pagination: {
     currentPage: 1,
     lastPage: 1,
@@ -55,6 +57,18 @@ const brandSlice = createSlice({
       state.loading = false;
       state.error = action.payload;
     },
+    fetchBrandRequest: (state, action: PayloadAction<{ brandId: string }>) => {
+      state.loading = true;
+      state.error = null;
+    },
+    fetchBrandSuccess: (state, action: PayloadAction<Brand>) => {
+      state.loading = false;
+      state.brand = action.payload;
+    },
+    fetchBrandFailure: (state, action: PayloadAction<string>) => {
+      state.loading = false;
+      state.error = action.payload;
+    },
     createBrandRequest: (state, action: PayloadAction<Partial<Brand>>) => {
       state.createLoading = true;
       state.createSuccess = false;
@@ -72,6 +86,16 @@ const brandSlice = createSlice({
       state.createSuccess = false;
       state.error = null;
     },
+    updateBrandField: (state, action: PayloadAction<{ field: keyof Brand; value: string }>) => {
+      if (state.brand) {
+        state.brand = { ...state.brand, [action.payload.field]: action.payload.value };
+      }
+    },
+    updateBrandFile: (state, action: PayloadAction<{ field: keyof Brand; file: File }>) => {
+      if (state.brand) {
+        state.brand = { ...state.brand, [action.payload.field]: action.payload.file };
+      }
+    },
   },
 });
 
@@ -82,10 +106,15 @@ export const {
   fetchMoreBrandsRequest,
   fetchMoreBrandsSuccess,
   fetchMoreBrandsFailure,
+  fetchBrandRequest,
+  fetchBrandSuccess,
+  fetchBrandFailure,
   createBrandRequest,
   createBrandSuccess,
   createBrandFailure,
   resetCreateStatus,
+  updateBrandField,
+  updateBrandFile,
 } = brandSlice.actions;
 
 export default brandSlice.reducer;


### PR DESCRIPTION
This commit introduces two main features:

1.  **Card View with Lazy Loading:**
    - Implements a card view for the brand list page.
    - Adds lazy loading to the card view, fetching more brands as the user scrolls down.
    - Replaces the `BrandMobileCard` with a more appropriate `BrandCard` component for the desktop card view.

2.  **Edit Form Data Binding:**
    - Fetches brand data from the `/api/venue/{id}` endpoint when the edit form is loaded.
    - Populates the edit form fields with the fetched data.
    - Uses Redux and Redux Saga to manage the state of the brand data in the edit form.