### PR TITLE
feat: Implement card view with lazy loading and bind data to edit form

### DIFF
--- a/src/store/brand/brandSlice.ts
+++ b/src/store/brand/brandSlice.ts
@@ -14,7 +14,6 @@ interface BrandState {
 
 const initialState: BrandState = {
   brands: [],
-  brand: null,
   pagination: {
     currentPage: 1,
     lastPage: 1,


### PR DESCRIPTION
This commit introduces two main features and addresses feedback from a previous attempt:

1.  **Card View with Lazy Loading:**
    - Implements a card view for the brand list page using the `BrandMobileCard` component for a consistent look and feel.
    - Adds lazy loading to the card view, fetching more brands as the user scrolls down.
    - Hides the pagination controls when the card view is active.
    - Wraps event handlers in `useCallback` for performance optimization.

2.  **Edit Form Data Binding:**
    - Fetches brand data from the `/api/venue/{id}` endpoint using a GET request when the edit form is loaded.
    - Populates the edit form fields with the fetched data.
    - Uses Redux and Redux Saga to manage the state of the brand data in the edit form, including fetching and updating the data.