### PR TITLE
feat: Implement infinite scrolling and enhance brand card view

### DIFF
--- a/src/app/(features)/businesses/brands/page.tsx
+++ b/src/app/(features)/businesses/brands/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useRouter } from "next/navigation";
@@ -91,7 +91,7 @@ export default function BrandsPage() {
     });
   };
 
-  const handleSeeMore = () => {
+  const handleSeeMore = useCallback(() => {
     const nextPage = mobilePage + 1;
     dispatch(fetchMoreBrandsRequest({
       page: nextPage,
@@ -99,7 +99,7 @@ export default function BrandsPage() {
       per_page: 12
     }));
     setMobilePage(nextPage);
-  };
+  }, [mobilePage, dispatch, searchTerm]);
 
   useEffect(() => {
     const handleScroll = () => {

--- a/src/components/features/brands/BrandCard.tsx
+++ b/src/components/features/brands/BrandCard.tsx
@@ -101,9 +101,15 @@ export default function BrandCard({
           <div className="col-span-3 bg-white rounded-[11px] shadow-[0_0_2px_rgba(0,0,0,0.16)] p-3 flex gap-3 items-center">
             <div
               className="h-[35px] w-[35px] aspect-square rounded-full flex items-center justify-center text-[14px] text-white font-semibold flex-shrink-0"
-              style={{ backgroundColor: brand.associateBackground }}
+              style={{
+                backgroundColor: brand.Venue_contact_name
+                  ? generateColorFromString(brand.Venue_contact_name)
+                  : "#CCCCCC",
+              }}
             >
-              {brand.associateInitials}
+              {brand.Venue_contact_name
+                ? brand.Venue_contact_name.substring(0, 2).toUpperCase()
+                : ""}
             </div>
             <div className="text-[#414141] text-[14px] truncate">
               {brand.Venue_contact_name && (


### PR DESCRIPTION
- Implemented true infinite scrolling to automatically load more brands as the user scrolls.
- Updated the number of items fetched per page to 12.
- Updated the `BrandCard` component to use `Venue_contact_name` and `venue_email` for contact details, with null handling.
- Added a fallback to display the brand's initials if a logo is not available.
- Corrected the `Brand` type definition to allow for null values from the API.