### PR TITLE
feat: Enhance brand card view with pagination and complete details

### DIFF
--- a/src/components/features/brands/BrandCard.tsx
+++ b/src/components/features/brands/BrandCard.tsx
@@ -1,8 +1,25 @@
 // components/BrandCard.tsx
 import Image from "next/image";
+import Link from "next/link";
 import { Brand } from "@/types/entities";
+import Checkbox from "@/components/general/CheckBox";
+import { generateColorFromString } from "@/utils/colorGenerator";
 
-export default function BrandCard({ brand }: { brand: Brand }) {
+interface BrandCardProps {
+  brand: Brand;
+  checked: boolean;
+  onCheckboxChange: () => void;
+}
+
+export default function BrandCard({
+  brand,
+  checked,
+  onCheckboxChange,
+}: BrandCardProps) {
+  const handleWrapperClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
   const items = [
     {
       id: "industry",
@@ -16,7 +33,7 @@ export default function BrandCard({ brand }: { brand: Brand }) {
       id: "instagram",
       iconSrc: "/icons/instagram-1-light.svg",
       iconAlt: "Instagram",
-      label: brand.instagramHandle,
+      label: brand.instagramHandle || "N/A",
       with: 27.8,
       height: 27.8,
     },
@@ -30,52 +47,86 @@ export default function BrandCard({ brand }: { brand: Brand }) {
     },
   ];
   return (
-    <div className="bg-white rounded-[13px] px-[21px] pt-[19px] pb-[22px] max-w-[400px] mx-auto">
-      {/* Profile circle */}
-      <div className="w-[90px] h-[90px] mx-auto overflow-hidden bg-white rounded-full border-5 border-[#E1E1E1]">
-        <Image src={brand.logo} alt={brand.name} width={80} height={80} />
-      </div>
-
-      {/* Brand name */}
-      <h2 className="mt-4 text-center text-[18px] font-medium text-[#4F4F4F]">
-        {brand.name}
-      </h2>
-
-      {/* Info items */}
-      <div className="mt-5 grid grid-cols-3 gap-2.5">
-        {items.map((item) => (
-          <div
-            key={item.id}
-            className="flex flex-col items-center bg-white rounded-[11px] shadow-[0_0_2px_rgba(0,0,0,0.16)] py-[18px] aspect-square"
-          >
-            <div className="h-[29px] flex items-center justify-center mb-3">
-              <Image
-                src={item.iconSrc}
-                alt={item.iconAlt}
-                width={item.with}
-                height={item.height}
-              />
+    <Link href={`/businesses/brands/${brand.brandId}`} className="block cursor-pointer">
+      <div className="bg-white rounded-[13px] px-[21px] pt-[19px] pb-[22px] max-w-[400px] mx-auto relative">
+        <div onClick={handleWrapperClick} className="absolute top-2 right-2">
+          <Checkbox
+            checked={checked}
+            onChange={onCheckboxChange}
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
+        {/* Profile circle */}
+        <div className="w-[90px] h-[90px] mx-auto overflow-hidden bg-white rounded-full border-5 border-[#E1E1E1] flex items-center justify-center">
+          {brand.logo ? (
+            <Image src={brand.logo} alt={brand.name} width={80} height={80} />
+          ) : (
+            <div
+              className="h-full w-full flex items-center justify-center"
+              style={{ backgroundColor: generateColorFromString(brand.name) }}
+            >
+              <span className="text-white text-3xl font-semibold">
+                {brand.name.substring(0, 2).toUpperCase()}
+              </span>
             </div>
-            <span className="text-[11px] text-[#414141] text-center truncate text-ellipsis max-w-[80px]">
-              {item.label}
-            </span>
-          </div>
-        ))}
-      </div>
-      <div className="flex gap-3 mt-5">
-        <div
-          className="h-[35px] w-[35px] aspect-square rounded-full flex items-center justify-center text-[14px] text-white font-semibold"
-          style={{ backgroundColor: brand.associateBackground }}
-        >
-          {brand.associateInitials}
+          )}
         </div>
-        <div className="text-[#414141] text-[14px]">
-          <p className="font-medium text-[13px] leading-[20px]">
-            {`${brand.associateFirstName} ${brand.associateLastName}`}
-          </p>
-          <p className="text-[11px] leading-[17px]">{brand.associateEmail}</p>
+
+        {/* Brand name */}
+        <h2 className="mt-4 text-center text-[18px] font-medium text-[#4F4F4F]">
+          {brand.name}
+        </h2>
+
+        {/* Info items */}
+        <div className="mt-5 grid grid-cols-3 gap-2.5">
+          {items.map((item) => (
+            <div
+              key={item.id}
+              className="flex flex-col items-center bg-white rounded-[11px] shadow-[0_0_2px_rgba(0,0,0,0.16)] py-[18px] aspect-square"
+            >
+              <div className="h-[29px] flex items-center justify-center mb-3">
+                <Image
+                  src={item.iconSrc}
+                  alt={item.iconAlt}
+                  width={item.with}
+                  height={item.height}
+                />
+              </div>
+              <span className="text-[11px] text-[#414141] text-center truncate text-ellipsis max-w-[80px]">
+                {item.label}
+              </span>
+            </div>
+          ))}
+          {(brand.Venue_contact_name || brand.venue_email) && (
+            <div className="col-span-3 bg-white rounded-[11px] shadow-[0_0_2px_rgba(0,0,0,0.16)] p-3 flex gap-3 items-center">
+              <div
+                className="h-[35px] w-[35px] aspect-square rounded-full flex items-center justify-center text-[14px] text-white font-semibold flex-shrink-0"
+                style={{
+                  backgroundColor: brand.Venue_contact_name
+                    ? generateColorFromString(brand.Venue_contact_name)
+                    : "#CCCCCC",
+                }}
+              >
+                {brand.Venue_contact_name
+                  ? brand.Venue_contact_name.substring(0, 2).toUpperCase()
+                  : ""}
+              </div>
+              <div className="text-[#414141] text-[14px] truncate">
+                {brand.Venue_contact_name && (
+                  <p className="font-medium text-[13px] leading-[20px] truncate">
+                    {brand.Venue_contact_name}
+                  </p>
+                )}
+                {brand.venue_email && (
+                  <p className="text-[11px] leading-[17px] truncate">
+                    {brand.venue_email}
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
         </div>
       </div>
-    </div>
+    </Link>
   );
 }

--- a/src/types/entities/brand.ts
+++ b/src/types/entities/brand.ts
@@ -27,4 +27,6 @@ export type Brand = {
   campaignsCount: number; // (Derived) Number of Campaigns this Brand runs
   profileCompletion: number; // (Derived) How complete the Brand's profile is for the UI
   files: number; // Number of files associated with the brand
+  Venue_contact_name: string | null;
+  venue_email: string | null;
 };


### PR DESCRIPTION
- Replaced the 'See More' button with a pagination component in the brands card view for a consistent user experience.
- Implemented a fallback to display the brand's initials if a logo is not available.
- Added the contact person's name and email to the card view, with null handling.
- Updated the Instagram field to display 'N/A' if the handle is null or empty.
- Corrected the `Brand` type definition to allow for null values from the API.