### PR TITLE
feat: Implement Complete Brand Edit Workflow and UI Enhancements

### DIFF
--- a/src/app/(features)/businesses/brands/[brandId]/page.tsx
+++ b/src/app/(features)/businesses/brands/[brandId]/page.tsx
@@ -14,6 +14,8 @@ import {
   initializeNewBrand,
   updateBrandField,
   updateBrandFile,
+  updateBrandRequest,
+  resetUpdateStatus,
 } from "@/store/brand/brandSlice";
 import { RootState } from "@/store/store";
 import { fetchIndustries } from "@/store/common/commonSlice";
@@ -25,7 +27,7 @@ export default function BrandPage() {
   const { brandId } = params;
   const isCreateMode = brandId === "create";
 
-  const { brand, loading, createLoading, createSuccess, error } = useSelector(
+  const { brand, loading, createLoading, createSuccess, updateLoading, updateSuccess, error } = useSelector(
     (state: RootState) => state.brand
   );
 
@@ -45,7 +47,11 @@ export default function BrandPage() {
       router.push("/businesses/brands");
       dispatch(resetCreateStatus());
     }
-  }, [createSuccess, router, dispatch]);
+    if (updateSuccess) {
+      router.push("/businesses/brands");
+      dispatch(resetUpdateStatus());
+    }
+  }, [createSuccess, updateSuccess, router, dispatch]);
 
   const handleFieldChange = (field: keyof Brand, value: string) => {
     dispatch(updateBrandField({ field, value }));
@@ -83,7 +89,12 @@ export default function BrandPage() {
       if (Object.keys(newErrors).length > 0) {
         return;
       }
-      dispatch(createBrandRequest(brand));
+
+      if (isCreateMode) {
+        dispatch(createBrandRequest(brand));
+      } else {
+        dispatch(updateBrandRequest(brand));
+      }
     }
   };
 
@@ -119,7 +130,7 @@ export default function BrandPage() {
             onFileChange: handleFileChange,
             isEditMode: true,
             onSave: handleSave,
-            isSaving: createLoading,
+            isSaving: createLoading || updateLoading,
             isCreateMode: isCreateMode,
             errors: validationErrors,
           }}

--- a/src/components/features/brands/BrandDetails.tsx
+++ b/src/components/features/brands/BrandDetails.tsx
@@ -399,9 +399,11 @@ export default function BrandDetails({
             </button>
           </div>
         </div>
-        <p className="text-sm text-[#4F4F4F] mt-4">
-          Registration date: {brand.registrationDate || "N/A"}
-        </p>
+        {brand.registrationDate && (
+          <p className="text-sm text-[#4F4F4F] mt-4">
+            Registration date: {new Date(brand.registrationDate).toLocaleDateString()}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/src/store/brand/brandSaga.ts
+++ b/src/store/brand/brandSaga.ts
@@ -14,6 +14,9 @@ import {
   createBrandRequest,
   createBrandSuccess,
   createBrandFailure,
+  updateBrandRequest,
+  updateBrandSuccess,
+  updateBrandFailure,
 } from './brandSlice';
 import { Brand } from '@/types/entities';
 
@@ -300,11 +303,59 @@ function* handleFetchBrand(action: ReturnType<typeof fetchBrandRequest>) {
   }
 }
 
+function* handleUpdateBrand(action: ReturnType<typeof updateBrandRequest>) {
+  try {
+    const brand = action.payload;
+    const brandId = brand.brandId;
+
+    if (!brandId) {
+      throw new Error("Brand ID is missing for update");
+    }
+
+    const formData = new FormData();
+    formData.append('venue_title', brand.name || '');
+    formData.append('company_name', brand.companyName || '');
+    formData.append('account_id', brand.accountId || '');
+    formData.append('country_id', brand.country || '');
+    formData.append('state_id', brand.state || '');
+    formData.append('category_id', brand.industry || '');
+    formData.append('venue_instagram_url', brand.instagramHandle || '');
+    formData.append('venue_url', brand.websiteUrl || '');
+    formData.append('Venue_contact_name', brand.associateName || '');
+    formData.append('venue_email', brand.associateEmail || '');
+    formData.append('venue_contact_number', brand.associatePhone || '');
+
+    if (brand.tradeLicenseCopy instanceof File) {
+      formData.append('trade_license_file', brand.tradeLicenseCopy);
+    }
+    if (brand.vatCertificate instanceof File) {
+      formData.append('vat_certificate_file', brand.vatCertificate);
+    }
+
+    const response: { message: string } | ApiError = yield call(postData, `/api/venue/${brandId}`, formData);
+
+    if ('message' in response) {
+      yield put(updateBrandSuccess());
+      toast.success(response.message);
+    } else {
+      const errorMessage = response.response || 'Failed to update brand';
+      yield put(updateBrandFailure(errorMessage));
+      toast.error(errorMessage);
+    }
+  } catch (error) {
+    const err = error as Error;
+    const errorMessage = err.message || 'An unknown error occurred';
+    yield put(updateBrandFailure(errorMessage));
+    toast.error(errorMessage);
+  }
+}
+
 function* watchBrand() {
   yield takeLatest(fetchBrandsRequest.type, handleFetchBrands);
   yield takeLatest(fetchMoreBrandsRequest.type, handleFetchMoreBrands);
   yield takeLatest(createBrandRequest.type, handleCreateBrand);
   yield takeLatest(fetchBrandRequest.type, handleFetchBrand);
+  yield takeLatest(updateBrandRequest.type, handleUpdateBrand);
 }
 
 export default function* brandSaga() {

--- a/src/store/brand/brandSlice.ts
+++ b/src/store/brand/brandSlice.ts
@@ -10,6 +10,8 @@ interface BrandState {
   error: string | null;
   createLoading: boolean;
   createSuccess: boolean;
+  updateLoading: boolean;
+  updateSuccess: boolean;
 }
 
 const initialState: BrandState = {
@@ -24,6 +26,8 @@ const initialState: BrandState = {
   error: null,
   createLoading: false,
   createSuccess: false,
+  updateLoading: false,
+  updateSuccess: false,
 };
 
 const brandSlice = createSlice({
@@ -100,6 +104,23 @@ const brandSlice = createSlice({
       state.loading = false;
       state.error = null;
     },
+    updateBrandRequest: (state, action: PayloadAction<Partial<Brand>>) => {
+      state.updateLoading = true;
+      state.updateSuccess = false;
+      state.error = null;
+    },
+    updateBrandSuccess: (state) => {
+      state.updateLoading = false;
+      state.updateSuccess = true;
+    },
+    updateBrandFailure: (state, action: PayloadAction<string>) => {
+      state.updateLoading = false;
+      state.error = action.payload;
+    },
+    resetUpdateStatus: (state) => {
+      state.updateSuccess = false;
+      state.error = null;
+    },
   },
 });
 
@@ -120,6 +141,10 @@ export const {
   updateBrandField,
   updateBrandFile,
   initializeNewBrand,
+  updateBrandRequest,
+  updateBrandSuccess,
+  updateBrandFailure,
+  resetUpdateStatus,
 } = brandSlice.actions;
 
 export default brandSlice.reducer;


### PR DESCRIPTION
This commit delivers a comprehensive set of features and fixes for the brand management workflow, addressing all user feedback and requirements.

- **Data Fetching and Binding:** Implemented a Redux Saga (`handleFetchBrand`) to fetch detailed data for a single brand from the `/api/venue/{id}` endpoint. This data is now correctly mapped and used to populate the fields when a user edits a brand.

- **Update Functionality:** Implemented a full Redux flow (`updateBrandRequest`, `updateBrandSuccess`, `updateBrandFailure`) and a corresponding saga (`handleUpdateBrand`) to handle the submission of updated brand data to the `/api/venue/{id}` endpoint.

- **Unified File Upload Component:** Created a new reusable `FileUploadField` component to provide a consistent UI for file uploads. This component handles both displaying existing files (with a download/re-upload icon) and selecting new files.

- **Dynamic Logo Fallback:** Implemented a new utility function, `getInitials`, to generate brand initials based on the brand name, correctly handling names with special characters like "&". This is now used consistently across the application as a fallback when a brand logo is not available.

- **Runtime Error Fixes:**
  - Resolved a crash on the "Add Brand" page by adding and correctly dispatching an `initializeNewBrand` action in the Redux slice to properly reset the form state.
  - Fixed a `setMobilePage is not defined` error on the brands listing page by removing an erroneous function call.

- **Data Consistency and UI Polish:**
  - Standardized the `industry` field in the brand data model to always store the ID, ensuring consistency.
  - Updated the `BrandsTable` to display the industry name instead of the ID.
  - Correctly formatted the registration date display on the edit page.
  - Hid the `subtitle` in the `BrandHeader` on the edit page as requested.