### PR TITLE
feat: implement brand list on account details page with fixes

### DIFF
--- a/src/components/features/accounts/AccountBrandCard.tsx
+++ b/src/components/features/accounts/AccountBrandCard.tsx
@@ -32,8 +32,23 @@ export default function AccountBrandCard({ brand }: { brand: Brand }) {
   return (
     <div className="bg-white rounded-[13px] px-[21px] pt-[19px] pb-[22px] max-w-md">
       {/* Profile circle */}
-      <div className="w-[90px] h-[90px] mx-auto overflow-hidden bg-white rounded-full border-5 border-[#E1E1E1]">
-        <Image src={brand.logo} alt={brand.name} width={80} height={80} />
+      <div className="w-[90px] h-[90px] mx-auto overflow-hidden bg-white rounded-full border-5 border-[#E1E1E1] flex items-center justify-center">
+        {brand.logo ? (
+          <Image
+            src={brand.logo}
+            alt={brand.name}
+            width={80}
+            height={80}
+            className="object-cover w-full h-full"
+          />
+        ) : (
+          <div
+            className="w-full h-full flex items-center justify-center text-white text-2xl font-bold"
+            style={{ backgroundColor: brand.associateBackground }}
+          >
+            {brand.associateInitials}
+          </div>
+        )}
       </div>
 
       {/* Brand name */}

--- a/src/components/features/accounts/AccountBrands.tsx
+++ b/src/components/features/accounts/AccountBrands.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 export default function AccountBrands({ brands }: { brands?: Brand[] }) {
   if (!brands || brands.length === 0) {
     return (
-      <div className="flex items-center justify-center min-h-[200px]">
+      <div className="bg-white rounded-lg shadow-md flex items-center justify-center min-h-[200px] w-full">
         <p className="text-gray-500">No brands found for this account.</p>
       </div>
     );

--- a/src/store/account/accountSaga.ts
+++ b/src/store/account/accountSaga.ts
@@ -1,8 +1,8 @@
-import { call, put, takeLatest, all } from 'redux-saga/effects';
-  import toast from 'react-hot-toast';
-  import { postData, deleteData, fetchData } from '@/services/commonService';
-  import { generateColorFromString } from '@/utils/colorGenerator';
-  import {
+import { call, put, takeLatest, all, select } from "redux-saga/effects";
+import toast from "react-hot-toast";
+import { postData, deleteData, fetchData } from "@/services/commonService";
+import { generateColorFromString } from "@/utils/colorGenerator";
+import {
     fetchAccountsRequest,
     fetchAccountsSuccess,
     fetchAccountsFailure,
@@ -27,46 +27,77 @@ import { call, put, takeLatest, all } from 'redux-saga/effects';
     bulkUpdateStatusRequest,
     bulkUpdateStatusSuccess,
     bulkUpdateStatusFailure,
-  } from './accountSlice';
-  import { Account, Brand, AccountType } from '@/types/entities';
+} from "./accountSlice";
+import { fetchIndustries, fetchIndustriesSuccess } from "../common/commonSlice";
+import { Account, Brand, AccountType } from "@/types/entities";
+import { RootState } from "../store";
+import { Option } from "@/types/common";
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const transformVenueToBrand = (venue: any): Brand => {
+const getIndustries = (state: RootState) => state.common.industries;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function* transformVenueToBrand(venue: any): Generator<any, Brand, any> {
+    let industries: Option[] = yield select(getIndustries);
+
+    if (!industries || industries.length === 0) {
+        yield put(fetchIndustries());
+        const response = yield call(fetchData, "/api/categories");
+        if (response && response.accounts) {
+            const formattedData: Option[] = response.accounts.map(
+                (industry: { id: number; category: string }) => ({
+                    value: industry.id.toString(),
+                    label: industry.category,
+                })
+            );
+            yield put(fetchIndustriesSuccess(formattedData));
+            industries = formattedData;
+        } else {
+            industries = [];
+        }
+    }
+
+    const industry = industries.find(
+        (ind) => ind.value === venue.category_id?.toString()
+    );
+
     return {
-      brandId: venue.id.toString(),
-      name: venue.venue_title,
-      accountId: venue.account_id ? venue.account_id.toString() : "N/A",
-      logo: venue.venue_logo || "/assets/images/brands/default-brand.png",
-      phoneNumber: venue.venue_contact_number || "",
-      emailAddress: venue.venue_email || "",
-      industry: venue.industry || "N/A",
-      companyName: venue.company_name || "",
-      businessLocation: venue.businessLocation || "",
-      tradeLicenseCopy: venue.trade_license_file || "",
-      vatCertificate: venue.vat_certificate_file || "",
-      instagramHandle: venue.venue_instagram_url || "",
-      websiteUrl: venue.venue_url || "",
-      associateFirstName: venue.associateFirstName || "",
-      associateLastName: venue.associateLastName || "",
-      associateEmail: venue.associateEmail || "",
-      associatePhone: venue.associatePhone || "",
-      associateInitials: venue.associateInitials || "",
-      associateBackground: venue.associateBackground || "#CCCCCC",
-      offersCount: venue.offersCount || 0,
-      campaignsCount: venue.campaignsCount || 0,
-      profileCompletion: venue.profileCompletion || 0,
-      country: venue.country || "",
-      state: venue.state || "",
-      associateName: venue.Venue_contact_name || "",
-      registrationDate: venue.created_at || "",
-      owner: venue.venue_title || "",
-      files: 0,
-      Venue_contact_name: venue.Venue_contact_name || null,
-      venue_email: venue.venue_email || null,
+        brandId: venue.id.toString(),
+        name: venue.venue_title,
+        accountId: venue.account_id ? venue.account_id.toString() : "N/A",
+        logo: venue.venue_logo || "",
+        phoneNumber: venue.venue_contact_number || "",
+        emailAddress: venue.venue_email || "",
+        industry: industry ? industry.label : "N/A",
+        companyName: venue.company_name || "",
+        businessLocation: venue.businessLocation || "",
+        tradeLicenseCopy: venue.trade_license_file || "",
+        vatCertificate: venue.vat_certificate_file || "",
+        instagramHandle: venue.venue_instagram_url || "",
+        websiteUrl: venue.venue_url || "",
+        associateFirstName: venue.associateFirstName || "",
+        associateLastName: venue.associateLastName || "",
+        associateEmail: venue.associateEmail || "",
+        associatePhone: venue.associatePhone || "",
+        associateInitials:
+            `${venue.venue_title?.[0] || ""}${
+                venue.venue_title?.split(" ")?.[1]?.[0] || ""
+            }`.toUpperCase() || "",
+        associateBackground: generateColorFromString(venue.venue_title || ""),
+        offersCount: venue.offersCount || 0,
+        campaignsCount: venue.campaignsCount || 0,
+        profileCompletion: venue.profileCompletion || 0,
+        country: venue.country || "",
+        state: venue.state || "",
+        associateName: venue.Venue_contact_name || "",
+        registrationDate: venue.created_at || "",
+        owner: venue.venue_title || "",
+        files: 0,
+        Venue_contact_name: venue.Venue_contact_name || null,
+        venue_email: venue.venue_email || null,
     };
-  };
+}
 
-  interface ApiAccount {
+interface ApiAccount {
     id: number;
     first_name: string;
     last_name: string;
@@ -79,14 +110,14 @@ import { call, put, takeLatest, all } from 'redux-saga/effects';
     venues: any[];
   venues_count: number;
     created_at: string;
-  }
+}
 
-  type ApiError = {
+type ApiError = {
     success: false;
     response: string;
-  };
+};
 
-  type FetchAccountsSuccessResponse = {
+type FetchAccountsSuccessResponse = {
     message: string;
     accounts: {
       data: ApiAccount[];
@@ -95,14 +126,14 @@ import { call, put, takeLatest, all } from 'redux-saga/effects';
       per_page: number;
       total: number;
     };
-  };
+};
 
-  type AccountSuccessResponse = {
+type AccountSuccessResponse = {
     message: string;
     account: ApiAccount;
-  };
+};
 
-  function* handleFetchAccounts(action: ReturnType<typeof fetchAccountsRequest>) {
+function* handleFetchAccounts(action: ReturnType<typeof fetchAccountsRequest>) {
     try {
       const { page, ...bodyPayload } = action.payload;
       let endpoint = '/api/list/accounts';
@@ -115,22 +146,25 @@ import { call, put, takeLatest, all } from 'redux-saga/effects';
       if ('accounts' in response && response.accounts) {
         const { data, current_page, last_page, per_page, total } = response.accounts;
 
-        const feAccounts: Account[] = data.map((apiAccount: ApiAccount) => ({
-          accountId: apiAccount.id.toString(),
-          firstName: apiAccount.first_name,
-          lastName: apiAccount.last_name,
-          emailAddress: apiAccount.email,
-          country_code: apiAccount.country_code,
-          phoneNumber: apiAccount.phone,
-          accountType: apiAccount.account_type as AccountType,
-          brands: apiAccount.venues ? apiAccount.venues.map(transformVenueToBrand) : [],
-          signUpDate: apiAccount.created_at,
-          avatarInitials: `${apiAccount.first_name?.[0] || ""}${apiAccount.last_name?.[0] || ""}`.toUpperCase(),
-          avatarBackground: generateColorFromString(apiAccount.first_name || ''),
-          subscriptionCount: 0,
-          brandsCount: apiAccount.venues_count || 0,
-          campaignsCount: 0,
-          status: apiAccount.status,
+        const feAccounts: Account[] = yield all(data.map(function*(apiAccount: ApiAccount) {
+          const brands = apiAccount.venues ? yield all(apiAccount.venues.map((venue: any) => call(transformVenueToBrand, venue))) : [];
+          return {
+            accountId: apiAccount.id.toString(),
+            firstName: apiAccount.first_name,
+            lastName: apiAccount.last_name,
+            emailAddress: apiAccount.email,
+            country_code: apiAccount.country_code,
+            phoneNumber: apiAccount.phone,
+            accountType: apiAccount.account_type as AccountType,
+            brands: brands,
+            signUpDate: apiAccount.created_at,
+            avatarInitials: `${apiAccount.first_name?.[0] || ""}${apiAccount.last_name?.[0] || ""}`.toUpperCase(),
+            avatarBackground: generateColorFromString(apiAccount.first_name || ''),
+            subscriptionCount: 0,
+            brandsCount: apiAccount.venues_count || 0,
+            campaignsCount: 0,
+            status: apiAccount.status,
+          };
         }));
 
         yield put(fetchAccountsSuccess({
@@ -154,9 +188,9 @@ import { call, put, takeLatest, all } from 'redux-saga/effects';
       yield put(fetchAccountsFailure(errorMessage));
       toast.error(errorMessage);
     }
-  }
+}
 
-  function* handleFetchMoreAccounts(action: ReturnType<typeof fetchMoreAccountsRequest>) {
+function* handleFetchMoreAccounts(action: ReturnType<typeof fetchMoreAccountsRequest>) {
     try {
       const { page, ...bodyPayload } = action.payload;
       let endpoint = '/api/list/accounts';
@@ -169,22 +203,25 @@ import { call, put, takeLatest, all } from 'redux-saga/effects';
       if ('accounts' in response && response.accounts) {
         const { data, current_page, last_page, per_page, total } = response.accounts;
 
-        const feAccounts: Account[] = data.map((apiAccount: ApiAccount) => ({
-          accountId: apiAccount.id.toString(),
-          firstName: apiAccount.first_name,
-          lastName: apiAccount.last_name,
-          emailAddress: apiAccount.email,
-          country_code: apiAccount.country_code,
-          phoneNumber: apiAccount.phone,
-          accountType: apiAccount.account_type as AccountType,
-          brands: apiAccount.venues ? apiAccount.venues.map(transformVenueToBrand) : [],
-          signUpDate: apiAccount.created_at,
-          avatarInitials: `${apiAccount.first_name?.[0] || ""}${apiAccount.last_name?.[0] || ""}`.toUpperCase(),
-          avatarBackground: generateColorFromString(apiAccount.first_name || ''),
-          subscriptionCount: 0,
-          brandsCount: apiAccount.venues_count || 0,
-          campaignsCount: 0,
-          status: apiAccount.status,
+        const feAccounts: Account[] = yield all(data.map(function*(apiAccount: ApiAccount) {
+          const brands = apiAccount.venues ? yield all(apiAccount.venues.map((venue: any) => call(transformVenueToBrand, venue))) : [];
+          return {
+            accountId: apiAccount.id.toString(),
+            firstName: apiAccount.first_name,
+            lastName: apiAccount.last_name,
+            emailAddress: apiAccount.email,
+            country_code: apiAccount.country_code,
+            phoneNumber: apiAccount.phone,
+            accountType: apiAccount.account_type as AccountType,
+            brands: brands,
+            signUpDate: apiAccount.created_at,
+            avatarInitials: `${apiAccount.first_name?.[0] || ""}${apiAccount.last_name?.[0] || ""}`.toUpperCase(),
+            avatarBackground: generateColorFromString(apiAccount.first_name || ''),
+            subscriptionCount: 0,
+            brandsCount: apiAccount.venues_count || 0,
+            campaignsCount: 0,
+            status: apiAccount.status,
+          };
         }));
 
         yield put(fetchMoreAccountsSuccess({
@@ -208,9 +245,9 @@ import { call, put, takeLatest, all } from 'redux-saga/effects';
       yield put(fetchMoreAccountsFailure(errorMessage));
       toast.error(errorMessage);
     }
-  }
+}
 
-  function* handleCreateAccount(action: ReturnType<typeof createAccountRequest>) {
+function* handleCreateAccount(action: ReturnType<typeof createAccountRequest>) {
     try {
       const {
         firstName,
@@ -239,6 +276,8 @@ import { call, put, takeLatest, all } from 'redux-saga/effects';
       if ('account' in response && response.account) {
         const apiAccount = response.account;
 
+        const feBrands: Brand[] = apiAccount.venues ? yield all(apiAccount.venues.map((venue: any) => call(transformVenueToBrand, venue))) : [];
+
         const feAccount: Account = {
           accountId: apiAccount.id.toString(),
           firstName: apiAccount.first_name,
@@ -247,7 +286,7 @@ import { call, put, takeLatest, all } from 'redux-saga/effects';
           country_code: apiAccount.country_code,
           phoneNumber: apiAccount.phone,
           accountType: apiAccount.account_type as AccountType,
-          brands: apiAccount.venues ? apiAccount.venues.map(transformVenueToBrand) : [],
+          brands: feBrands,
           signUpDate: apiAccount.created_at,
           avatarInitials: `${apiAccount.first_name?.[0] || ""}${apiAccount.last_name?.[0] || ""}`.toUpperCase(),
           avatarBackground: "#CCCCCC",
@@ -271,9 +310,9 @@ import { call, put, takeLatest, all } from 'redux-saga/effects';
       yield put(createAccountFailure(errorMessage));
       toast.error(errorMessage);
     }
-  }
+}
 
-  function* handleUpdateAccount(action: ReturnType<typeof updateAccountRequest>) {
+function* handleUpdateAccount(action: ReturnType<typeof updateAccountRequest>) {
     try {
       const {
         accountId,
@@ -309,6 +348,7 @@ import { call, put, takeLatest, all } from 'redux-saga/effects';
       );
       if ('account' in response && response.account) {
         const apiAccount = response.account;
+        const feBrands: Brand[] = apiAccount.venues ? yield all(apiAccount.venues.map((venue: any) => call(transformVenueToBrand, venue))) : [];
         const feAccount: Account = {
           accountId: apiAccount.id.toString(),
           firstName: apiAccount.first_name,
@@ -317,9 +357,7 @@ import { call, put, takeLatest, all } from 'redux-saga/effects';
           country_code: apiAccount.country_code,
           phoneNumber: apiAccount.phone,
           accountType: apiAccount.account_type as AccountType,
-          brands: apiAccount.venues
-            ? apiAccount.venues.map(transformVenueToBrand)
-            : [],
+          brands: feBrands,
           signUpDate: apiAccount.created_at,
           avatarInitials: `${apiAccount.first_name?.[0] || ""}${
             apiAccount.last_name?.[0] || ""
@@ -344,9 +382,9 @@ import { call, put, takeLatest, all } from 'redux-saga/effects';
       yield put(updateAccountFailure(errorMessage));
       toast.error(errorMessage);
     }
-  }
+}
 
-  function* handleDeleteAccount(action: ReturnType<typeof deleteAccountRequest>) {
+function* handleDeleteAccount(action: ReturnType<typeof deleteAccountRequest>) {
     try {
       const { accountId } = action.payload;
       const response: { success: boolean, response: string } = yield call(deleteData, `/api/accounts/${accountId}`);
@@ -364,15 +402,16 @@ import { call, put, takeLatest, all } from 'redux-saga/effects';
       yield put(deleteAccountFailure(errorMessage));
       toast.error(errorMessage);
     }
-  }
+}
 
-  function* handleFetchAccountById(action: ReturnType<typeof fetchAccountByIdRequest>) {
+function* handleFetchAccountById(action: ReturnType<typeof fetchAccountByIdRequest>) {
     try {
       const { accountId } = action.payload;
       const response: AccountSuccessResponse | ApiError = yield call(fetchData, `/api/account/${accountId}`);
 
       if ('account' in response && response.account) {
         const apiAccount = response.account;
+        const feBrands: Brand[] = apiAccount.venues ? yield all(apiAccount.venues.map((venue: any) => call(transformVenueToBrand, venue))) : [];
         const feAccount: Account = {
           accountId: apiAccount.id.toString(),
           firstName: apiAccount.first_name,
@@ -381,7 +420,7 @@ import { call, put, takeLatest, all } from 'redux-saga/effects';
           country_code: apiAccount.country_code,
           phoneNumber: apiAccount.phone,
           accountType: apiAccount.account_type as AccountType,
-          brands: apiAccount.venues ? apiAccount.venues.map(transformVenueToBrand) : [],
+          brands: feBrands,
           signUpDate: apiAccount.created_at,
           avatarInitials: `${apiAccount.first_name?.[0] || ""}${apiAccount.last_name?.[0] || ""}`.toUpperCase(),
           avatarBackground: generateColorFromString(apiAccount.first_name || ''),
@@ -403,9 +442,9 @@ import { call, put, takeLatest, all } from 'redux-saga/effects';
       yield put(fetchAccountByIdFailure(errorMessage));
       toast.error(errorMessage);
     }
-  }
+}
 
-  function* handleBulkDeleteAccounts(action: ReturnType<typeof bulkDeleteAccountsRequest>) {
+function* handleBulkDeleteAccounts(action: ReturnType<typeof bulkDeleteAccountsRequest>) {
     try {
       const { account_ids } = action.payload;
       const response: { message: string, updated_ids: string[] } | ApiError = yield call(postData, '/api/accounts/bulk-delete', { account_ids });
@@ -427,9 +466,9 @@ import { call, put, takeLatest, all } from 'redux-saga/effects';
       yield put(bulkDeleteAccountsFailure(errorMessage));
       toast.error(errorMessage);
     }
-  }
+}
 
-  function* handleBulkUpdateStatus(action: ReturnType<typeof bulkUpdateStatusRequest>) {
+function* handleBulkUpdateStatus(action: ReturnType<typeof bulkUpdateStatusRequest>) {
     try {
       const { account_ids, status } = action.payload;
       const response: { message: string, updated_ids: string[], status: string } | ApiError = yield call(postData, '/api/accounts/bulk-update-status', { account_ids, status });
@@ -451,9 +490,9 @@ import { call, put, takeLatest, all } from 'redux-saga/effects';
       yield put(bulkUpdateStatusFailure(errorMessage));
       toast.error(errorMessage);
     }
-  }
+}
 
-  function* watchAccount() {
+function* watchAccount() {
     yield takeLatest(fetchAccountsRequest.type, handleFetchAccounts);
     yield takeLatest(fetchMoreAccountsRequest.type, handleFetchMoreAccounts);
     yield takeLatest(createAccountRequest.type, handleCreateAccount);
@@ -462,10 +501,10 @@ import { call, put, takeLatest, all } from 'redux-saga/effects';
     yield takeLatest(fetchAccountByIdRequest.type, handleFetchAccountById);
     yield takeLatest(bulkDeleteAccountsRequest.type, handleBulkDeleteAccounts);
     yield takeLatest(bulkUpdateStatusRequest.type, handleBulkUpdateStatus);
-  }
+}
 
 export default function* accountSaga() {
-  yield all([
-    watchAccount(),
-  ]);
+    yield all([
+      watchAccount(),
+    ]);
 }


### PR DESCRIPTION
This commit implements the feature to display a list of brands on the account details page. It addresses the following feedback:

- Styles the 'No brands found' message with a white background.
- Correctly binds the industry data by mapping the category_id to a category name.
- Implements a fallback for brand logos, displaying the brand's initials if a logo is not available.