### PR TITLE
feat: Implement role-based sidebar and no records found messages

### DIFF
--- a/src/app/(features)/businesses/accounts/page.tsx
+++ b/src/app/(features)/businesses/accounts/page.tsx
@@ -204,15 +204,21 @@ export default function AccountsPage() {
           {!loading && !error && (
             <>
               <div className="md:hidden space-y-[7px]">
-                {accounts.map((account) => (
-                  <AccountCard
-                    key={account.accountId}
-                    account={account}
-                    checked={checkedRows.has(account.accountId)}
-                    onCheckboxChange={() => handleCheckboxChange(account.accountId)}
-                  />
-                ))}
-                {accounts.length < pagination.total && (
+                {accounts.length === 0 ? (
+                  <div className="text-center py-10 text-gray-500">
+                    No records found.
+                  </div>
+                ) : (
+                  accounts.map((account) => (
+                    <AccountCard
+                      key={account.accountId}
+                      account={account}
+                      checked={checkedRows.has(account.accountId)}
+                      onCheckboxChange={() => handleCheckboxChange(account.accountId)}
+                    />
+                  ))
+                )}
+                {accounts.length > 0 && accounts.length < pagination.total && (
                   <div className="text-center font-semibold text-[15px] text-gray-500 my-4 mb-8">
                     <button
                       onClick={handleSeeMore}

--- a/src/app/(features)/businesses/brands/page.tsx
+++ b/src/app/(features)/businesses/brands/page.tsx
@@ -173,14 +173,20 @@ export default function BrandsPage() {
                   />
                 ) : (
                   <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-                    {brands.map((brand) => (
-                      <BrandCard
-                        key={brand.brandId}
-                        brand={brand}
-                        checked={checkedRows.has(brand.brandId)}
-                        onCheckboxChange={() => handleCheckboxChange(brand.brandId)}
-                      />
-                    ))}
+                    {brands.length === 0 ? (
+                      <div className="col-span-full text-center py-10 text-gray-500">
+                        No records found.
+                      </div>
+                    ) : (
+                      brands.map((brand) => (
+                        <BrandCard
+                          key={brand.brandId}
+                          brand={brand}
+                          checked={checkedRows.has(brand.brandId)}
+                          onCheckboxChange={() => handleCheckboxChange(brand.brandId)}
+                        />
+                      ))
+                    )}
                   </div>
                 )}
                 {loading && brands.length > 0 && <div className="text-center py-4"><InlineLoader /></div>}
@@ -195,16 +201,22 @@ export default function BrandsPage() {
                 )}
               </div>
               <div className="md:hidden space-y-[7px]">
-                {brands.map((brand) => (
-                  <BrandMobileCard
-                    key={brand.brandId}
-                    brand={brand}
-                    checked={checkedRows.has(brand.brandId)}
-                    onCheckboxChange={() => handleCheckboxChange(brand.brandId)}
-                  />
-                ))}
+                {brands.length === 0 ? (
+                  <div className="text-center py-10 text-gray-500">
+                    No records found.
+                  </div>
+                ) : (
+                  brands.map((brand) => (
+                    <BrandMobileCard
+                      key={brand.brandId}
+                      brand={brand}
+                      checked={checkedRows.has(brand.brandId)}
+                      onCheckboxChange={() => handleCheckboxChange(brand.brandId)}
+                    />
+                  ))
+                )}
                 {loading && brands.length > 0 && <div className="text-center py-4"><InlineLoader /></div>}
-                {brands.length < pagination.total && !loading && (
+                {brands.length > 0 && brands.length < pagination.total && !loading && (
                   <div className="text-center font-semibold text-[15px] text-gray-500 my-4 mb-8">
                     <button
                       onClick={handleSeeMore}

--- a/src/app/(features)/businesses/campaigns/page.tsx
+++ b/src/app/(features)/businesses/campaigns/page.tsx
@@ -101,17 +101,23 @@ export default function CampaignsPage() {
             </div>
           )}
           <div className="md:hidden space-y-[7px]">
-            {CampaignsData.map((campaign) => {
-              const accountId = getAccountIdFromBrandId(campaign.brandId);
-              return (
-                <Link
-                  key={campaign.campaignId}
-                  href={`/businesses/accounts/${accountId}/${campaign.brandId}/${campaign.campaignId}`}
-                >
-                  <CampaignsMobileCard campaign={campaign} />
-                </Link>
-              );
-            })}
+            {CampaignsData.length === 0 ? (
+              <div className="text-center py-10 text-gray-500">
+                No records found.
+              </div>
+            ) : (
+              CampaignsData.map((campaign) => {
+                const accountId = getAccountIdFromBrandId(campaign.brandId);
+                return (
+                  <Link
+                    key={campaign.campaignId}
+                    href={`/businesses/accounts/${accountId}/${campaign.brandId}/${campaign.campaignId}`}
+                  >
+                    <CampaignsMobileCard campaign={campaign} />
+                  </Link>
+                );
+              })
+            )}
           </div>
           <div className="hidden md:block">
             {view === "table" ? (
@@ -131,17 +137,23 @@ export default function CampaignsPage() {
             ) : (
               <>
                 <div className="grid grid-cols-[repeat(auto-fit,340px)] gap-x-[13px] gap-y-[20px] justify-center mb-8">
-                  {CampaignsData.map((campaign) => {
-                    const accountId = getAccountIdFromBrandId(campaign.brandId);
-                    return (
-                      <Link
-                        key={campaign.campaignId}
-                        href={`/businesses/accounts/${accountId}/${campaign.brandId}/${campaign.campaignId}`}
-                      >
-                        <CampaignCard campaign={campaign} />
-                      </Link>
-                    );
-                  })}
+                  {CampaignsData.length === 0 ? (
+                    <div className="col-span-full text-center py-10 text-gray-500">
+                      No records found.
+                    </div>
+                  ) : (
+                    CampaignsData.map((campaign) => {
+                      const accountId = getAccountIdFromBrandId(campaign.brandId);
+                      return (
+                        <Link
+                          key={campaign.campaignId}
+                          href={`/businesses/accounts/${accountId}/${campaign.brandId}/${campaign.campaignId}`}
+                        >
+                          <CampaignCard campaign={campaign} />
+                        </Link>
+                      );
+                    })
+                  )}
                 </div>
               </>
             )}

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { useSelector } from "react-redux";
+import { RootState } from "@/store/store";
 import { sidebarConfig } from "@/utils/sidebar-config";
 
 const IconContainer = ({ children }: { children: React.ReactNode }) => (
@@ -22,9 +24,20 @@ export default function Sidebar({
   setCollapsed: setControlledCollapsed,
   setIsMobileMenuOpen,
 }: SidebarProps) {
+  const { user } = useSelector((state: RootState) => state.auth);
   const [internalCollapsed, setInternalCollapsed] = useState(false);
   const [windowWidth, setWindowWidth] = useState(1920); // Default for SSR
   const [isMounted, setIsMounted] = useState(false);
+
+  const filteredSidebarConfig = sidebarConfig.map((section) => {
+    if (user?.registration_type !== "admin") {
+      return {
+        ...section,
+        items: section.items.filter((item) => item.label !== "Accounts"),
+      };
+    }
+    return section;
+  }).filter(section => section.items.length > 0);
 
   // Use controlled or internal state
   const collapsed =
@@ -97,7 +110,7 @@ export default function Sidebar({
         </div>
       </div>
       <nav className="flex-1 pl-[25px] pr-[25px] xl:pl-[25px] xl:pr-[30px]">
-        {sidebarConfig.map((section, sectionIndex) => (
+        {filteredSidebarConfig.map((section, sectionIndex) => (
           <div key={sectionIndex} className="mb-7.25">
             {section.title && (
               <p

--- a/src/components/features/accounts/AccountsTable.tsx
+++ b/src/components/features/accounts/AccountsTable.tsx
@@ -88,8 +88,15 @@ export default function AccountsTable({
         </thead>
 
         <tbody className="bg-white">
-          {accounts.map((account) => (
-            <tr key={account.accountId} className="odd:bg-[#F8F8F8]">
+          {accounts.length === 0 ? (
+            <tr>
+              <td colSpan={8} className="py-10 text-center text-gray-500">
+                No records found.
+              </td>
+            </tr>
+          ) : (
+            accounts.map((account) => (
+              <tr key={account.accountId} className="odd:bg-[#F8F8F8]">
               <td className="px-4.75 py-2.5 whitespace-nowrap">
                 <div className="flex items-center">
                   <Checkbox

--- a/src/components/features/brands/BrandsTable.tsx
+++ b/src/components/features/brands/BrandsTable.tsx
@@ -89,8 +89,15 @@ export default function BrandsTable({
           </tr>
         </thead>
         <tbody className="bg-white">
-          {brands.map((brand) => (
-            <tr key={brand.brandId} className="odd:bg-[#F8F8F8]">
+          {brands.length === 0 ? (
+            <tr>
+              <td colSpan={7} className="py-10 text-center text-gray-500">
+                No records found.
+              </td>
+            </tr>
+          ) : (
+            brands.map((brand) => (
+              <tr key={brand.brandId} className="odd:bg-[#F8F8F8]">
               <td className="px-4.75 py-2.5 whitespace-nowrap">
                 <div className="flex items-center">
                   <Checkbox

--- a/src/components/features/campaigns/CampaignsTable.tsx
+++ b/src/components/features/campaigns/CampaignsTable.tsx
@@ -101,10 +101,17 @@ export default function CampaignsTable({
         </thead>
 
         <tbody className="bg-white">
-          {campaigns.map((campaign) => {
-            const accountId = getAccountIdFromBrandId(campaign.brandId);
-            return (
-              <tr key={campaign.campaignId} className="odd:bg-[#F8F8F8]">
+          {campaigns.length === 0 ? (
+            <tr>
+              <td colSpan={7} className="py-10 text-center text-gray-500">
+                No records found.
+              </td>
+            </tr>
+          ) : (
+            campaigns.map((campaign) => {
+              const accountId = getAccountIdFromBrandId(campaign.brandId);
+              return (
+                <tr key={campaign.campaignId} className="odd:bg-[#F8F8F8]">
                 <td className="px-4.75 py-2.5 whitespace-nowrap">
                   <div className="flex items-center">
                     <Checkbox

--- a/src/store/auth/authSaga.ts
+++ b/src/store/auth/authSaga.ts
@@ -48,9 +48,10 @@ function* handleLogin(action: ReturnType<typeof loginRequest>) {
         phoneNumber: account.phone,
         country_code: account.country_code,
         accountType: account.account_type as AccountType,
+        registration_type: account.registration_type,
         signUpDate: account.created_at,
         status: account.status as "active" | "inactive",
-        avatarInitials: `${account.first_name.charAt(0)}${account.last_name.charAt(0)}`,
+        avatarInitials: `${account.first_name.charAt(0)}${account.last_name ? account.last_name.charAt(0) : ''}`.toUpperCase(),
         avatarBackground: '#000000', // Default background color
         subscriptionCount: 0,
         brandsCount: 0,

--- a/src/types/entities/account.ts
+++ b/src/types/entities/account.ts
@@ -47,6 +47,9 @@ export type Account = {
   /** Account type - Individual or Agency */
   accountType: AccountType;
 
+  /** Registration type - e.g., "admin", "account" */
+  registration_type: string;
+
   /** When the account was created */
   signUpDate: string | null;
 


### PR DESCRIPTION
This commit introduces several features and fixes based on user feedback:

- **Role-Based Sidebar:** The sidebar now conditionally renders the 'Accounts' menu item, making it visible only to users with an 'admin' registration type.
- **No Records Found Message:** All main list pages (Accounts, Brands, Campaigns) now display a 'No records found' message in both table and card views when the API returns an empty list.
- **Data Model Update:** The `Account` type and authentication saga have been updated to include and handle the `registration_type` field from the API.