### PR TITLE
fix: Correct file upload payload

### DIFF
--- a/src/components/features/brands/BrandFilesModal.tsx
+++ b/src/components/features/brands/BrandFilesModal.tsx
@@ -72,9 +72,9 @@ const BrandFilesModal = ({ isOpen, onClose, brandId }: BrandFilesModalProps) => 
 
     const formData = new FormData();
     formData.append("venue_id", brandId);
-    formData.append("uploaded_by", createdBy);
+    formData.append("updatedBy", createdBy);
     files.forEach((file) => {
-      formData.append("menu_pdf[]", file);
+      formData.append("menu_pdf", file);
     });
 
     try {


### PR DESCRIPTION
- Changes the `uploaded_by` key to `updatedBy` in the file upload payload.
- Adjusts the `menu_pdf` key to correctly send an array of files.