### PR TITLE
feat: Implement brand files modal with all feedback

### DIFF
--- a/src/components/features/brands/BrandFilesModal.tsx
+++ b/src/components/features/brands/BrandFilesModal.tsx
@@ -205,8 +205,8 @@ const BrandFilesModal = ({ isOpen, onClose, brandId }: BrandFilesModalProps) => 
                   brandFiles.map((file) => (
                     <tr key={file.id}>
                       <td className="px-6 py-4 whitespace-nowrap text-sm text-blue-500">
-                        <a href={`${process.env.NEXT_PUBLIC_API_BASE_URL}/${file.venue_file_url}`} download>
-                          {file.venue_file_url}
+                        <a href={`${process.env.NEXT_PUBLIC_API_BASE_URL}/${file.venue_file_url}`} target="_blank" rel="noopener noreferrer">
+                          {`${process.env.NEXT_PUBLIC_API_BASE_URL}/${file.venue_file_url}`}
                         </a>
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{formatDate(file.created_at)}</td>


### PR DESCRIPTION
- Adds a modal to upload and view files for a brand.
- Implements file upload with a correctly formatted payload.
- Fetches and displays existing files, constructing full, downloadable URLs using the NEXT_PUBLIC_API_BASE_URL environment variable.
- Updates the UI to match the application's theme and removes the 'Edit' button as requested.
- Displays the full URL in the table and opens links in a new tab.