### PR TITLE
feat: Implement brand files modal with all feedback

### DIFF
--- a/src/components/features/brands/BrandFilesModal.tsx
+++ b/src/components/features/brands/BrandFilesModal.tsx
@@ -92,6 +92,19 @@ const BrandFilesModal = ({ isOpen, onClose, brandId }: BrandFilesModalProps) => 
     }
   };
 
+  const handleDelete = async (venueFileId: number) => {
+    if (!window.confirm("Are you sure you want to delete this file?")) {
+      return;
+    }
+
+    try {
+      await api.post("/api/delete/venue_file", { venue_file_id: venueFileId });
+      fetchBrandFiles(); // Refresh the list
+    } catch (err) {
+      setError("Failed to delete file.");
+    }
+  };
+
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString("en-GB", {
       day: "2-digit",
@@ -212,7 +225,10 @@ const BrandFilesModal = ({ isOpen, onClose, brandId }: BrandFilesModalProps) => 
                       <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{formatDate(file.created_at)}</td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{file.uploaded_by}</td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                        <button className="text-red-600 hover:text-red-900">
+                        <button
+                          onClick={() => handleDelete(file.id)}
+                          className="text-red-600 hover:text-red-900"
+                        >
                           Delete
                         </button>
                       </td>


### PR DESCRIPTION
- Adds a modal to upload, view, and delete files for a brand.
- Implements file upload and delete with correctly formatted payloads.
- Fetches and displays existing files, constructing full, clickable URLs using the NEXT_PUBLIC_API_BASE_URL environment variable.
- Updates the UI to match the application's theme.
- Includes a confirmation dialog for the delete action.