### PR TITLE
feat: Implement brand files modal with all feedback

### DIFF
--- a/src/components/features/brands/BrandFilesModal.tsx
+++ b/src/components/features/brands/BrandFilesModal.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "@/store/store";
+import { deleteBrandFileRequest, resetDeleteFileStatus } from "@/store/brand/brandSlice";
 import api from "@/services/apiHelper";
 import InlineLoader from "@/components/general/InlineLoader";
 
@@ -25,6 +28,9 @@ const BrandFilesModal = ({ isOpen, onClose, brandId }: BrandFilesModalProps) => 
   const [uploading, setUploading] = useState(false);
   const [loadingFiles, setLoadingFiles] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const dispatch = useDispatch();
+  const { deleteFileSuccess } = useSelector((state: RootState) => state.brand);
 
   const fetchBrandFiles = useCallback(async () => {
     if (!brandId) return;
@@ -92,16 +98,16 @@ const BrandFilesModal = ({ isOpen, onClose, brandId }: BrandFilesModalProps) => 
     }
   };
 
-  const handleDelete = async (venueFileId: number) => {
-    if (!window.confirm("Are you sure you want to delete this file?")) {
-      return;
+  useEffect(() => {
+    if (deleteFileSuccess) {
+      fetchBrandFiles();
+      dispatch(resetDeleteFileStatus());
     }
+  }, [deleteFileSuccess, fetchBrandFiles, dispatch]);
 
-    try {
-      await api.post("/api/delete/venue_file", { venue_file_id: venueFileId });
-      fetchBrandFiles(); // Refresh the list
-    } catch (err) {
-      setError("Failed to delete file.");
+  const handleDelete = (venueFileId: number) => {
+    if (window.confirm("Are you sure you want to delete this file?")) {
+      dispatch(deleteBrandFileRequest({ venue_file_id: venueFileId }));
     }
   };
 

--- a/src/store/brand/brandSaga.ts
+++ b/src/store/brand/brandSaga.ts
@@ -17,6 +17,9 @@ import {
   updateBrandRequest,
   updateBrandSuccess,
   updateBrandFailure,
+  deleteBrandFileRequest,
+  deleteBrandFileSuccess,
+  deleteBrandFileFailure,
 } from './brandSlice';
 import { Brand } from '@/types/entities';
 
@@ -350,12 +353,33 @@ function* handleUpdateBrand(action: ReturnType<typeof updateBrandRequest>) {
   }
 }
 
+function* handleDeleteBrandFile(action: ReturnType<typeof deleteBrandFileRequest>) {
+  try {
+    const response: { message: string } | ApiError = yield call(postData, '/api/delete/venue_file', action.payload);
+
+    if ('message' in response) {
+      yield put(deleteBrandFileSuccess());
+      toast.success(response.message);
+    } else {
+      const errorMessage = response.response || 'Failed to delete file';
+      yield put(deleteBrandFileFailure(errorMessage));
+      toast.error(errorMessage);
+    }
+  } catch (error) {
+    const err = error as Error;
+    const errorMessage = err.message || 'An unknown error occurred';
+    yield put(deleteBrandFileFailure(errorMessage));
+    toast.error(errorMessage);
+  }
+}
+
 function* watchBrand() {
   yield takeLatest(fetchBrandsRequest.type, handleFetchBrands);
   yield takeLatest(fetchMoreBrandsRequest.type, handleFetchMoreBrands);
   yield takeLatest(createBrandRequest.type, handleCreateBrand);
   yield takeLatest(fetchBrandRequest.type, handleFetchBrand);
   yield takeLatest(updateBrandRequest.type, handleUpdateBrand);
+  yield takeLatest(deleteBrandFileRequest.type, handleDeleteBrandFile);
 }
 
 export default function* brandSaga() {

--- a/src/store/brand/brandSlice.ts
+++ b/src/store/brand/brandSlice.ts
@@ -12,6 +12,8 @@ interface BrandState {
   createSuccess: boolean;
   updateLoading: boolean;
   updateSuccess: boolean;
+  deleteFileLoading: boolean;
+  deleteFileSuccess: boolean;
 }
 
 const initialState: BrandState = {
@@ -28,6 +30,8 @@ const initialState: BrandState = {
   createSuccess: false,
   updateLoading: false,
   updateSuccess: false,
+  deleteFileLoading: false,
+  deleteFileSuccess: false,
 };
 
 const brandSlice = createSlice({
@@ -121,6 +125,22 @@ const brandSlice = createSlice({
       state.updateSuccess = false;
       state.error = null;
     },
+    deleteBrandFileRequest: (state, action: PayloadAction<{ venue_file_id: number }>) => {
+      state.deleteFileLoading = true;
+      state.deleteFileSuccess = false;
+      state.error = null;
+    },
+    deleteBrandFileSuccess: (state) => {
+      state.deleteFileLoading = false;
+      state.deleteFileSuccess = true;
+    },
+    deleteBrandFileFailure: (state, action: PayloadAction<string>) => {
+      state.deleteFileLoading = false;
+      state.error = action.payload;
+    },
+    resetDeleteFileStatus: (state) => {
+      state.deleteFileSuccess = false;
+    }
   },
 });
 
@@ -145,6 +165,10 @@ export const {
   updateBrandSuccess,
   updateBrandFailure,
   resetUpdateStatus,
+  deleteBrandFileRequest,
+  deleteBrandFileSuccess,
+  deleteBrandFileFailure,
+  resetDeleteFileStatus,
 } = brandSlice.actions;
 
 export default brandSlice.reducer;


### PR DESCRIPTION
- Adds a modal to upload, view, and delete files for a brand.
- Implements file upload and delete with correctly formatted payloads and Redux actions.
- Fetches and displays existing files, constructing full, clickable URLs using the NEXT_PUBLIC_API_BASE_URL environment variable.
- Updates the UI to match the application's theme.
- Includes a confirmation dialog for the delete action.