### PR TITLE
feat: Implement brand file management and fixes

### DIFF
--- a/src/app/(features)/businesses/brands/[brandId]/page.tsx
+++ b/src/app/(features)/businesses/brands/[brandId]/page.tsx
@@ -102,8 +102,12 @@ export default function BrandPage() {
     return <Loader />;
   }
 
+  if (error && !isCreateMode) {
+    return <p className="text-red-500 text-center py-10">Error: {error}</p>;
+  }
+
   if (!brand && !isCreateMode) {
-    return <p className="text-red-500">Brand not found.</p>;
+    return <Loader />;
   }
 
   return (

--- a/src/components/general/PinModal.tsx
+++ b/src/components/general/PinModal.tsx
@@ -25,7 +25,7 @@ export default function PinModal({ isOpen, onClose, onSubmit, loading, error }: 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
       <div className="bg-white p-6 rounded-lg shadow-lg w-full max-w-sm">
-        <h2 className="text-xl font-bold mb-4">Enter PIN to Download</h2>
+        <h2 className="text-xl font-bold mb-4">Pin Validation</h2>
         <form onSubmit={handleSubmit}>
           <input
             type="password"
@@ -48,7 +48,7 @@ export default function PinModal({ isOpen, onClose, onSubmit, loading, error }: 
               disabled={loading}
               className="px-4 py-2 bg-blue-500 text-white rounded-md disabled:bg-gray-400"
             >
-              {loading ? "Verifying..." : "Submit"}
+              {loading ? "Validating..." : "Validate"}
             </button>
           </div>
         </form>

--- a/src/store/common/commonSaga.ts
+++ b/src/store/common/commonSaga.ts
@@ -13,6 +13,9 @@ import {
   fetchAllAccounts,
   fetchAllAccountsSuccess,
   fetchAllAccountsFailure,
+  validatePinRequest,
+  validatePinSuccess,
+  validatePinFailure,
 } from "./commonSlice";
 import { PayloadAction } from "@reduxjs/toolkit";
 import { Option } from "@/types/common";
@@ -101,11 +104,25 @@ function* fetchAllAccountsSaga() {
   }
 }
 
+function* handleValidatePin(action: PayloadAction<{ pin: string }>) {
+  try {
+    const response = yield call(postData, "/api/validate/pin", action.payload);
+    if (response.success) {
+      yield put(validatePinSuccess());
+    } else {
+      yield put(validatePinFailure(response.message || "Invalid PIN"));
+    }
+  } catch (error) {
+    yield put(validatePinFailure((error as Error).message));
+  }
+}
+
 function* commonSaga() {
   yield takeLatest(fetchCountries.type, fetchCountriesSaga);
   yield takeLatest(fetchStates.type, fetchStatesSaga);
   yield takeLatest(fetchIndustries.type, fetchIndustriesSaga);
   yield takeLatest(fetchAllAccounts.type, fetchAllAccountsSaga);
+  yield takeLatest(validatePinRequest.type, handleValidatePin);
 }
 
 export default commonSaga;

--- a/src/store/common/commonSlice.ts
+++ b/src/store/common/commonSlice.ts
@@ -18,6 +18,9 @@ interface CommonState {
     industries: string | null;
     allAccounts: string | null;
   };
+  pinValidationLoading: boolean;
+  pinValidationSuccess: boolean;
+  pinValidationError: string | null;
 }
 
 const initialState: CommonState = {
@@ -37,6 +40,9 @@ const initialState: CommonState = {
     industries: null,
     allAccounts: null,
   },
+  pinValidationLoading: false,
+  pinValidationSuccess: false,
+  pinValidationError: null,
 };
 
 const commonSlice = createSlice({
@@ -92,6 +98,23 @@ const commonSlice = createSlice({
       state.error.allAccounts = action.payload;
       state.loading.allAccounts = false;
     },
+    validatePinRequest: (state, action: PayloadAction<{ pin: string }>) => {
+      state.pinValidationLoading = true;
+      state.pinValidationSuccess = false;
+      state.pinValidationError = null;
+    },
+    validatePinSuccess: (state) => {
+      state.pinValidationLoading = false;
+      state.pinValidationSuccess = true;
+    },
+    validatePinFailure: (state, action: PayloadAction<string>) => {
+      state.pinValidationLoading = false;
+      state.pinValidationError = action.payload;
+    },
+    resetPinStatus: (state) => {
+      state.pinValidationSuccess = false;
+      state.pinValidationError = null;
+    },
   },
 });
 
@@ -108,6 +131,10 @@ export const {
   fetchAllAccounts,
   fetchAllAccountsSuccess,
   fetchAllAccountsFailure,
+  validatePinRequest,
+  validatePinSuccess,
+  validatePinFailure,
+  resetPinStatus,
 } = commonSlice.actions;
 
 export default commonSlice.reducer;


### PR DESCRIPTION
- Fixes a bug where the brand edit page would show a 'Brand not found' error on refresh.
- Implements a PIN validation flow for all file downloads on the brand edit page and in the files modal.
- Adds a modal to upload, view, and delete files for a brand.
- Implements file upload and delete with correctly formatted payloads and Redux actions.
- Fetches and displays existing files, constructing full, clickable URLs using the NEXT_PUBLIC_API_BASE_URL environment variable.
- Updates the UI to match the application's theme.
- Uses a toast notification for the delete confirmation.