### PR TITLE
feat: Implement brand file management and fixes

### DIFF
--- a/src/components/features/brands/BrandDetails.tsx
+++ b/src/components/features/brands/BrandDetails.tsx
@@ -166,7 +166,12 @@ export default function BrandDetails({
 
   useEffect(() => {
     if (pinValidationSuccess && fileToDownload) {
-      window.open(fileToDownload, "_blank");
+      const link = document.createElement("a");
+      link.href = fileToDownload;
+      link.setAttribute("download", "");
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
       setFileToDownload(null);
       setIsPinModalOpen(false);
       dispatch(resetPinStatus());

--- a/src/components/features/brands/BrandFilesModal.tsx
+++ b/src/components/features/brands/BrandFilesModal.tsx
@@ -113,7 +113,12 @@ const BrandFilesModal = ({ isOpen, onClose, brandId }: BrandFilesModalProps) => 
 
   useEffect(() => {
     if (pinValidationSuccess && fileToDownload) {
-      window.open(`${process.env.NEXT_PUBLIC_API_BASE_URL}/${fileToDownload}`, "_blank");
+      const link = document.createElement("a");
+      link.href = `${process.env.NEXT_PUBLIC_API_BASE_URL}/${fileToDownload}`;
+      link.setAttribute("download", "");
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
       setFileToDownload(null);
       setIsPinModalOpen(false);
       dispatch(resetPinStatus());

--- a/src/components/general/PinModal.tsx
+++ b/src/components/general/PinModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 interface PinModalProps {
   isOpen: boolean;
@@ -13,6 +13,12 @@ interface PinModalProps {
 export default function PinModal({ isOpen, onClose, onSubmit, loading, error }: PinModalProps) {
   const [pin, setPin] = useState("");
 
+  useEffect(() => {
+    if (isOpen) {
+      setPin(""); // Clear the pin when the modal opens
+    }
+  }, [isOpen]);
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     onSubmit(pin);
@@ -23,7 +29,7 @@ export default function PinModal({ isOpen, onClose, onSubmit, loading, error }: 
   }
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
+    <div className="fixed inset-0 bg-transparent flex justify-center items-center z-50">
       <div className="bg-white p-6 rounded-lg shadow-lg w-full max-w-sm">
         <h2 className="text-xl font-bold mb-4">Pin Validation</h2>
         <form onSubmit={handleSubmit}>


### PR DESCRIPTION
- Fixes a bug where the brand edit page would show a 'Brand not found' error on refresh.
- Implements a PIN validation flow for all file downloads on the brand edit page and in the files modal.
- Adds a modal to upload, view, and delete files for a brand.
- Implements file upload and delete with correctly formatted payloads and Redux actions.
- Fetches and displays existing files, constructing full, clickable URLs using the NEXT_PUBLIC_API_BASE_URL environment variable.
- Updates the UI to match the application's theme, including a transparent modal backdrop and an icon for the delete button.
- Uses a toast notification for the delete confirmation.
- Ensures files are downloaded instead of opened in a new tab.