### PR TITLE
feat: Implement brand file management and fixes

### DIFF
--- a/src/components/features/brands/BrandDetails.tsx
+++ b/src/components/features/brands/BrandDetails.tsx
@@ -165,29 +165,17 @@ export default function BrandDetails({
   const [fileToDownload, setFileToDownload] = useState<string | null>(null);
 
   useEffect(() => {
-    const downloadFile = async () => {
-      if (pinValidationSuccess && fileToDownload) {
-        try {
-          const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/${fileToDownload}`);
-          const blob = await response.blob();
-          const url = window.URL.createObjectURL(blob);
-          const link = document.createElement("a");
-          link.href = url;
-          link.setAttribute("download", fileToDownload.split('/').pop() || "download");
-          document.body.appendChild(link);
-          link.click();
-          document.body.removeChild(link);
-          window.URL.revokeObjectURL(url);
-        } catch (error) {
-          console.error("Download failed:", error);
-        } finally {
-          setFileToDownload(null);
-          setIsPinModalOpen(false);
-          dispatch(resetPinStatus());
-        }
-      }
-    };
-    downloadFile();
+    if (pinValidationSuccess && fileToDownload) {
+      const link = document.createElement("a");
+      link.href = `${process.env.NEXT_PUBLIC_API_BASE_URL}/${fileToDownload}`;
+      link.setAttribute("download", fileToDownload.split('/').pop() || "download");
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      setFileToDownload(null);
+      setIsPinModalOpen(false);
+      dispatch(resetPinStatus());
+    }
   }, [pinValidationSuccess, fileToDownload, dispatch]);
 
   const handlePinSubmit = (pin: string) => {

--- a/src/components/features/brands/BrandFilesModal.tsx
+++ b/src/components/features/brands/BrandFilesModal.tsx
@@ -112,29 +112,17 @@ const BrandFilesModal = ({ isOpen, onClose, brandId }: BrandFilesModalProps) => 
   }, [deleteFileSuccess, fetchBrandFiles, dispatch]);
 
   useEffect(() => {
-    const downloadFile = async () => {
-      if (pinValidationSuccess && fileToDownload) {
-        try {
-          const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/${fileToDownload}`);
-          const blob = await response.blob();
-          const url = window.URL.createObjectURL(blob);
-          const link = document.createElement("a");
-          link.href = url;
-          link.setAttribute("download", fileToDownload.split('/').pop() || "download");
-          document.body.appendChild(link);
-          link.click();
-          document.body.removeChild(link);
-          window.URL.revokeObjectURL(url);
-        } catch (error) {
-          console.error("Download failed:", error);
-        } finally {
-          setFileToDownload(null);
-          setIsPinModalOpen(false);
-          dispatch(resetPinStatus());
-        }
-      }
-    };
-    downloadFile();
+    if (pinValidationSuccess && fileToDownload) {
+      const link = document.createElement("a");
+      link.href = `${process.env.NEXT_PUBLIC_API_BASE_URL}/${fileToDownload}`;
+      link.setAttribute("download", fileToDownload.split('/').pop() || "download");
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      setFileToDownload(null);
+      setIsPinModalOpen(false);
+      dispatch(resetPinStatus());
+    }
   }, [pinValidationSuccess, fileToDownload, dispatch]);
 
   const handleDownloadRequest = (fileUrl: string) => {


### PR DESCRIPTION
- Fixes a bug where the brand edit page would show a 'Brand not found' error on refresh.
- Fixes a bug where the 'Accounts' menu was not visible for admin users.
- Implements a PIN validation flow for all file downloads on the brand edit page and in the files modal.
- Implements a robust download mechanism to force file downloads instead of opening in a new tab.
- Adds a modal to upload, view, and delete files for a brand.
- Implements file upload and delete with correctly formatted payloads and Redux actions.
- Fetches and displays existing files, constructing full, clickable URLs using the NEXT_PUBLIC_API_BASE_URL environment variable.
- Updates the UI to match the application's theme, including a transparent modal backdrop and an icon for the delete button.
- Uses a toast notification for the delete confirmation.