### PR TITLE
feat: Implement brand file management and fixes

### DIFF
--- a/src/components/features/brands/BrandDetails.tsx
+++ b/src/components/features/brands/BrandDetails.tsx
@@ -166,7 +166,7 @@ export default function BrandDetails({
 
   useEffect(() => {
     if (pinValidationSuccess && fileToDownload) {
-      window.open(fileToDownload, "_blank");
+      window.open(`${process.env.NEXT_PUBLIC_API_BASE_URL}/${fileToDownload}`, "_blank");
       setFileToDownload(null);
       setIsPinModalOpen(false);
       dispatch(resetPinStatus());

--- a/src/components/features/brands/BrandFilesModal.tsx
+++ b/src/components/features/brands/BrandFilesModal.tsx
@@ -112,23 +112,23 @@ const BrandFilesModal = ({ isOpen, onClose, brandId }: BrandFilesModalProps) => 
     }
   }, [deleteFileSuccess, fetchBrandFiles, dispatch]);
 
-  useEffect(() => {
-    if (pinValidationSuccess && fileToDownload) {
-      window.open(`${process.env.NEXT_PUBLIC_API_BASE_URL}/${fileToDownload}`, "_blank");
-      setFileToDownload(null);
-      setIsPinModalOpen(false);
-      dispatch(resetPinStatus());
-    }
-  }, [pinValidationSuccess, fileToDownload, dispatch]);
+  // useEffect(() => {
+  //   if (pinValidationSuccess && fileToDownload) {
+  //     window.open(`${process.env.NEXT_PUBLIC_API_BASE_URL}/${fileToDownload}`, "_blank");
+  //     setFileToDownload(null);
+  //     setIsPinModalOpen(false);
+  //     dispatch(resetPinStatus());
+  //   }
+  // }, [pinValidationSuccess, fileToDownload, dispatch]);
 
-  const handleDownloadRequest = (fileUrl: string) => {
-    setFileToDownload(fileUrl);
-    setIsPinModalOpen(true);
-  };
+  // const handleDownloadRequest = (fileUrl: string) => {
+  //   setFileToDownload(fileUrl);
+  //   setIsPinModalOpen(true);
+  // };
 
-  const handlePinSubmit = (pin: string) => {
-    dispatch(validatePinRequest({ pin }));
-  };
+  // const handlePinSubmit = (pin: string) => {
+  //   dispatch(validatePinRequest({ pin }));
+  // };
 
   const handleDelete = (venueFileId: number) => {
     toast((t) => (
@@ -270,9 +270,9 @@ const BrandFilesModal = ({ isOpen, onClose, brandId }: BrandFilesModalProps) => 
                   brandFiles.map((file) => (
                     <tr key={file.id}>
                       <td className="px-6 py-4 whitespace-nowrap text-sm text-blue-500">
-                        <button onClick={() => handleDownloadRequest(file.venue_file_url)} className="text-left hover:underline">
+                        <a href={`${process.env.NEXT_PUBLIC_API_BASE_URL}/${file.venue_file_url}`} target="_blank" rel="noopener noreferrer" className="text-left hover:underline">
                           {`${process.env.NEXT_PUBLIC_API_BASE_URL}/${file.venue_file_url}`}
-                        </button>
+                        </a>
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{formatDate(file.created_at)}</td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{file.uploaded_by}</td>
@@ -300,16 +300,6 @@ const BrandFilesModal = ({ isOpen, onClose, brandId }: BrandFilesModalProps) => 
           </div>
         </div>
       </div>
-      <PinModal
-        isOpen={isPinModalOpen}
-        onClose={() => {
-          setIsPinModalOpen(false);
-          dispatch(resetPinStatus());
-        }}
-        onSubmit={handlePinSubmit}
-        loading={pinValidationLoading}
-        error={pinValidationError}
-      />
     </div>
   );
 };


### PR DESCRIPTION
- Fixes a bug where the brand edit page would show a 'Brand not found' error on refresh.
- Fixes a bug where the 'Accounts' menu was not visible for admin users.
- Fixes incorrect URL construction for file downloads on the brand edit page.
- Implements a PIN validation flow for file downloads on the brand edit page.
- Temporarily disables PIN validation in the brand files modal as requested.
- Adds a modal to upload, view, and delete files for a brand.
- Implements file upload and delete with correctly formatted payloads and Redux actions.
- Updates the UI to match the application's theme.