### PR TITLE
fix: Prevent crash in BrandSearchCombobox due to undefined accounts

### DIFF
--- a/src/utils/brandUtils.ts
+++ b/src/utils/brandUtils.ts
@@ -9,7 +9,10 @@ export const transformApiVenueToBrand = (apiVenue: any): Brand => {
     brandId: apiVenue.id.toString(),
     name: apiVenue.venue_title,
     companyName: apiVenue.company_name,
-    accountId: apiVenue.accounts.length > 0 ? apiVenue.accounts[0].id.toString() : "",
+    accountId:
+      apiVenue.accounts && apiVenue.accounts.length > 0
+        ? apiVenue.accounts[0].id.toString()
+        : "",
     country: apiVenue.country_id,
     state: apiVenue.state_id,
     industry: apiVenue.category_id,


### PR DESCRIPTION
Previously, the `transformApiVenueToBrand` function would throw a TypeError if `apiVenue.accounts` was undefined, as it tried to access the `length` property without a prior check. This change adds a defensive check to ensure `apiVenue.accounts` is defined and is an array before accessing its properties, thus preventing the crash in the BrandSearchCombobox component.