### PR TITLE
fix: Enable tab functionality on brand page

### DIFF
--- a/src/app/(features)/businesses/brands/[brandId]/page.tsx
+++ b/src/app/(features)/businesses/brands/[brandId]/page.tsx
@@ -32,6 +32,7 @@ export default function BrandPage() {
   const { user } = useSelector((state: RootState) => state.auth);
 
   const [validationErrors, setValidationErrors] = useState<Partial<Record<keyof Brand, string>>>({});
+  const [activeTab, setActiveTab] = useState("Business Details");
 
   useEffect(() => {
     dispatch(fetchIndustries());
@@ -139,12 +140,13 @@ export default function BrandPage() {
           // subtitle={brand?.businessLocation || ""}
           logo={brand?.logo}
           tabs={["Business Details", "Campaigns"]}
-          activeTab="Business Details"
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
         />
       )}
       <div className="pb-6">
         <BrandTabContent
-          activeTab="Business Details"
+          activeTab={activeTab}
           brand={{
             ...brand,
             onFieldChange: handleFieldChange,


### PR DESCRIPTION
This commit fixes a bug where the tabs on the brand details page were not functional. The `activeTab` prop was hardcoded, preventing users from switching between the "Business Details" and "Campaigns" tabs.

State management for the active tab has been added to the main brand page component. The `activeTab` state is now passed down to the `BrandHeader` and `BrandTabContent` components, allowing them to be updated dynamically when a user clicks on a tab.

This change restores the intended tab functionality and improves the user experience on the brand details page.