### PR TITLE
style: Highlight active menu item in sidebar

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useSelector } from "react-redux";
 import { RootState } from "@/store/store";
 import { sidebarConfig } from "@/utils/sidebar-config";
@@ -24,6 +25,7 @@ export default function Sidebar({
   setCollapsed: setControlledCollapsed,
   setIsMobileMenuOpen,
 }: SidebarProps) {
+  const pathname = usePathname();
   const { user } = useSelector((state: RootState) => state.auth);
   const [internalCollapsed, setInternalCollapsed] = useState(false);
   const [windowWidth, setWindowWidth] = useState(1920); // Default for SSR
@@ -126,37 +128,50 @@ export default function Sidebar({
               </p>
             )}
             <ul className={section.title ? "mt-1 space-y-1" : ""}>
-              {section.items.map((item, itemIndex) => (
-                <li key={itemIndex}>
-                  <Link
-                    href={item.href}
-                    onClick={() => setIsMobileMenuOpen?.(false)}
-                    className={
-                      collapsed
-                        ? "flex items-center justify-center w-[52px] aspect-square  text-[#414141] rounded-[11px] hover:bg-[#F1F1F1]"
-                        : "flex items-center w-[227px] gap-4.5 px-[9.2px] py-[12.5px] text-[#414141] rounded-[11px] hover:bg-[#F1F1F1]"
-                    }
-                  >
-                    <IconContainer>
-                      <Image
-                        src={item.icon.src}
-                        alt={item.icon.alt}
-                        width={item.icon.width}
-                        height={item.icon.height}
-                      />
-                    </IconContainer>
-                    <span
-                      className={
+              {section.items.map((item, itemIndex) => {
+                const isActive = pathname.startsWith(item.href);
+                const iconSrc = isActive
+                  ? item.icon.src.replace("/sidebar/", "/sidebar/darkmode/")
+                  : item.icon.src;
+
+                return (
+                  <li key={itemIndex}>
+                    <Link
+                      href={item.href}
+                      onClick={() => setIsMobileMenuOpen?.(false)}
+                      className={`${
                         collapsed
-                          ? "hidden"
-                          : "text-lg text-[#4F4F4F] leading-[1.5]"
-                      }
+                          ? "flex items-center justify-center w-[52px] aspect-square"
+                          : "flex items-center w-[227px] gap-4.5 px-[9.2px] py-[12.5px]"
+                      } rounded-[11px] ${
+                        isActive
+                          ? "bg-[#008C9E] text-white"
+                          : "text-[#414141] hover:bg-[#F1F1F1]"
+                      }`}
                     >
-                      {item.label}
-                    </span>
-                  </Link>
-                </li>
-              ))}
+                      <IconContainer>
+                        <Image
+                          src={iconSrc}
+                          alt={item.icon.alt}
+                          width={item.icon.width}
+                          height={item.icon.height}
+                        />
+                      </IconContainer>
+                      <span
+                        className={
+                          collapsed
+                            ? "hidden"
+                            : `text-lg leading-[1.5] ${
+                                isActive ? "text-white" : "text-[#4F4F4F]"
+                              }`
+                        }
+                      >
+                        {item.label}
+                      </span>
+                    </Link>
+                  </li>
+                );
+              })}
             </ul>
           </div>
         ))}


### PR DESCRIPTION
This commit implements a visual enhancement to the sidebar by highlighting the active menu item. The active link now has a background color of #008C9E and white text, making it easier for users to identify the current page.

- The `usePathname` hook is used to get the current URL path.
- The active link is determined by comparing its `href` with the current path.
- The `className` of the link is dynamically updated to apply the new styles.
- The icon is also switched to a different version for the active state.