### PR TITLE
fix: Correct campaign navigation from brand edit page

### DIFF
--- a/src/components/features/brands/BrandCampaigns.tsx
+++ b/src/components/features/brands/BrandCampaigns.tsx
@@ -3,21 +3,30 @@
 import CampaignCard from "../campaigns/CampaignCard";
 import BrandCampaignMobileCard from "./BrandCampaignMobileCard";
 import { CampaignsData } from "@/data/CampaignsData";
+import { brandsData } from "@/data/BrandsData";
 import { useRouter } from "next/navigation";
+import { Campaign } from "@/types/entities";
 
-interface BrandCampaignsProps {
-  brandId: string;
-  accountId: string;
-}
+interface BrandCampaignsProps {}
 
-export default function BrandCampaigns({
-  brandId,
-  accountId,
-}: BrandCampaignsProps) {
+export default function BrandCampaigns({}: BrandCampaignsProps) {
   const router = useRouter();
 
-  const handleCampaignClick = (campaignId: string) => {
-    router.push(`/businesses/accounts/${accountId}/${brandId}/${campaignId}`);
+  const brandAccountMap = new Map<string, string>();
+  brandsData.forEach((brand) => {
+    brandAccountMap.set(brand.brandId, brand.accountId);
+  });
+
+  const handleCampaignClick = (campaign: Campaign) => {
+    const campaignAccountId = brandAccountMap.get(campaign.brandId);
+    if (campaignAccountId) {
+      router.push(
+        `/businesses/accounts/${campaignAccountId}/${campaign.brandId}/${campaign.campaignId}`
+      );
+    } else {
+      // Fallback for safety, though data should be consistent
+      console.error(`Account ID not found for brand ID: ${campaign.brandId}`);
+    }
   };
 
   const brandCampaigns = CampaignsData;
@@ -41,7 +50,7 @@ export default function BrandCampaigns({
           {brandCampaigns.map((campaign) => (
             <div
               key={campaign.campaignId}
-              onClick={() => handleCampaignClick(campaign.campaignId)}
+              onClick={() => handleCampaignClick(campaign)}
               className="cursor-pointer"
             >
               <CampaignCard campaign={campaign} />
@@ -53,7 +62,7 @@ export default function BrandCampaigns({
         {brandCampaigns.map((campaign) => (
           <div
             key={campaign.campaignId}
-            onClick={() => handleCampaignClick(campaign.campaignId)}
+            onClick={() => handleCampaignClick(campaign)}
             className="cursor-pointer"
           >
             <BrandCampaignMobileCard campaign={campaign} />

--- a/src/components/features/brands/BrandTabContent.tsx
+++ b/src/components/features/brands/BrandTabContent.tsx
@@ -36,10 +36,7 @@ export default function BrandTabContent({
       case "Campaigns":
         return (
           <div>
-            <BrandCampaigns
-              brandId={brand.brandId || ""}
-              accountId={brand.accountId || ""}
-            />
+            <BrandCampaigns />
           </div>
         );
       default:


### PR DESCRIPTION
This commit fixes a bug where clicking on a campaign card on the brand edit page would result in a broken URL. The issue was caused by using the `accountId` of the brand being edited, rather than the `accountId` of the campaign being clicked.

The fix involves looking up the correct `accountId` for each campaign from the mock data and using it to construct the navigation URL. This ensures that clicking on a campaign card always navigates to the correct campaign details page.