### PR TITLE
fix: Resolve all type errors in brand slice, saga, and types

### DIFF
--- a/src/store/brand/brandSlice.ts
+++ b/src/store/brand/brandSlice.ts
@@ -100,7 +100,41 @@ const brandSlice = createSlice({
       }
     },
     initializeNewBrand: (state) => {
-      state.brand = {};
+      state.brand = {
+        brandId: '',
+        accountId: '',
+        name: '',
+        owner: '',
+        logo: '',
+        phoneNumber: '',
+        emailAddress: '',
+        industry: '',
+        companyName: '',
+        country: '',
+        state: '',
+        businessLocation: '',
+        tradeLicenseCopy: '',
+        vatCertificate: '',
+        instagramHandle: '',
+        websiteUrl: '',
+        associateName: '',
+        associateEmail: '',
+        associatePhone: '',
+        associateFirstName: '',
+        associateLastName: '',
+        associateInitials: '',
+        associateBackground: '',
+        registrationDate: '',
+        offersCount: 0,
+        campaignsCount: 0,
+        profileCompletion: 0,
+        files: 0,
+        Venue_contact_name: null,
+        venue_email: null,
+        Venue: {
+          food_offers: [],
+        },
+      };
       state.loading = false;
       state.error = null;
     },


### PR DESCRIPTION
This commit provides a comprehensive fix for multiple TypeScript errors that were causing build failures across `brandSlice.ts`, `brandSaga.ts`, and `api.ts`.

Four main issues were addressed:
1.  The `initialState` in `src/store/brand/brandSlice.ts` was missing the required `brand` property, which has been added and initialized to `null`.
2.  The `initializeNewBrand` reducer in `src/store/brand/brandSlice.ts` was incorrectly assigning an empty object to `state.brand`. It now initializes a complete, default `Brand` object.
3.  A missing `PaginationState` type definition in `src/types/api.ts` was added, resolving an import error.
4.  The mapping logic in `src/store/brand/brandSaga.ts` was corrected to handle `null` values from the API for properties that expect a `string` type. A fallback to an empty string (`''`) is now used, and all required properties are correctly mapped in all brand-fetching functions.