### PR TITLE
fix: Resolve all build and runtime errors across the application

### DIFF
--- a/src/components/features/brands/BrandCard.tsx
+++ b/src/components/features/brands/BrandCard.tsx
@@ -25,7 +25,7 @@ export default function BrandCard({
 
   const { industries } = useSelector((state: RootState) => state.common);
   const industryMap = new Map(industries.map(i => [i.value, i.label]));
-  const industryName = industryMap.get(brand.industry) || 'N/A';
+  const industryName = brand.industry ? (industryMap.get(brand.industry) || 'N/A') : 'N/A';
 
   const items = [
     {


### PR DESCRIPTION
This commit provides a comprehensive fix for a cascade of TypeScript build errors and subsequent runtime errors across multiple files.

The root cause was an incorrect `Brand` type definition that did not accurately reflect the API response. This led to a series of incorrect patches and further errors. This final commit addresses all known issues at their source:

1.  **`src/types/entities/brand.ts`**: Corrected the `Brand` type to allow `null` for properties that are nullable in the API response.
2.  **`src/types/api.ts`**: Added missing `PaginationState` and `ValidatePinResponse` type definitions.
3.  **`src/store/brand/brandSlice.ts`**: Fixed the `initialState` to include the `brand` property and corrected the `initializeNewBrand` reducer to create a valid, default `Brand` object.
4.  **`src/store/common/commonSaga.ts`**: Resolved an implicit 'any' type error by applying an explicit type to a `yield` expression result.
5.  **`src/store/brand/brandSaga.ts`**: Simplified and corrected all data mappings to align with the new `Brand` type, removing incorrect fallbacks and ensuring all required properties are mapped.
6.  **`src/utils/brandUtils.ts`**: Corrected the `transformApiVenueToBrand` function to return a complete `Brand` object.
7.  **`src/components/features/brands/BrandCard.tsx`**: Fixed a type error by handling a potential `null` value before a map lookup.
8.  **`src/components/features/brands/BrandCampaigns.tsx`**: Fixed a runtime error by ensuring unique keys are generated for rendered list items.
9. **`src/components/features/campaigns/CampaignCard.tsx`**: Fixed a runtime error by adding a conditional check to prevent passing a null `src` to the Image component.
10. **`src/app/(features)/businesses/accounts/[accountId]/[brandId]/layout.tsx`**: Fixed downstream type errors by correctly handling `null` prop values.
11. **`src/app/(features)/businesses/brands/[brandId]/page.tsx`**: Fixed downstream type errors by correctly handling `null` prop values.