### PR TITLE
feat: Implement campaign list page with API integration

### DIFF
--- a/src/app/(features)/businesses/campaigns/page.tsx
+++ b/src/app/(features)/businesses/campaigns/page.tsx
@@ -1,162 +1,220 @@
 "use client";
 
+import { useEffect, useState, useRef } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useDebounce } from "@/hooks/useDebounce";
+import { useRouter } from "next/navigation";
+import { fetchCampaignsRequest, fetchMoreCampaignsRequest } from "@/store/campaign/campaignSlice";
+import { setSearchTerm } from "@/store/search/searchSlice";
+import { RootState } from "@/store/store";
 import CampaignsTable from "@/components/features/campaigns/CampaignsTable";
 import CampaignCard from "@/components/features/campaigns/CampaignCard";
 import CampaignsMobileCard from "@/components/features/campaigns/CampaignMobileCard";
-import TableCardsToggler from "@/components/general/TableCardsToggler";
 import Pagination from "@/components/general/Pagination";
-import { CampaignsData } from "@/data/CampaignsData";
-import { brandsData } from "@/data/BrandsData";
-import { useState } from "react";
-import SearchInputMobile from "@/components/general/SearchInputMobile";
-import SortDropdown from "@/components/general/dropdowns/SortDropdown";
 import ActionDropdown from "@/components/general/dropdowns/ActionDropdown";
+import SearchInputMobile from "@/components/general/SearchInputMobile";
 import Image from "next/image";
 import Link from "next/link";
+import Loader from "@/components/general/Loader";
+import InlineLoader from "@/components/general/InlineLoader";
+import TableCardsToggler from "@/components/general/TableCardsToggler";
 
 export default function CampaignsPage() {
-  const [currentPage, setCurrentPage] = useState(1);
-  const [itemsPerPage, setItemsPerPage] = useState(10);
+  const router = useRouter();
+  const dispatch = useDispatch();
+  const {
+    campaigns,
+    pagination,
+    loading,
+    error,
+  } = useSelector((state: RootState) => state.campaign);
+
+  const { searchTerm } = useSelector((state: RootState) => state.search);
+  const [checkedRows, setCheckedRows] = useState<Set<string>>(new Set());
   const [view, setView] = useState<"table" | "card">("table");
-  const [search, setSearch] = useState("");
+  const [mobilePage, setMobilePage] = useState(1);
 
-  // Function to get accountId from brandId
-  const getAccountIdFromBrandId = (brandId: string): string => {
-    const brand = brandsData.find((b) => b.brandId === brandId);
-    return brand?.accountId || "0"; // fallback to "0" if brand not found
-  };
+  const debouncedSearch = useDebounce(searchTerm, 500);
 
-  // Calculate pagination for desktop view only
-  const indexOfLastItem = currentPage * itemsPerPage;
-  const indexOfFirstItem = indexOfLastItem - itemsPerPage;
-  const currentCampaigns = CampaignsData.slice(
-    indexOfFirstItem,
-    indexOfLastItem
-  );
+  useEffect(() => {
+    dispatch(fetchCampaignsRequest({ per_page: 12, page: 1, search: '' }));
+  }, [dispatch]);
+
+  const isInitialSearchMount = useRef(true);
+  useEffect(() => {
+    if (isInitialSearchMount.current) {
+      isInitialSearchMount.current = false;
+      return;
+    }
+
+    setMobilePage(1);
+    dispatch(fetchCampaignsRequest({
+      search: debouncedSearch,
+      per_page: 12,
+      page: 1
+    }));
+  }, [debouncedSearch, dispatch]);
 
   const handlePageChange = (page: number) => {
-    setCurrentPage(page);
+    dispatch(fetchCampaignsRequest({
+      page,
+      search: searchTerm,
+      per_page: pagination.perPage
+    }));
   };
 
   const handleItemsPerPageChange = (items: number) => {
-    setItemsPerPage(items);
-    setCurrentPage(1);
-  };
-
-  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearch(e.target.value);
-  };
-
-  const handleSortSelect = (value: string) => {
-    console.log("Sort selected:", value);
-    // Add your sort logic here
+    dispatch(fetchCampaignsRequest({ search: searchTerm, per_page: items, page: 1 }));
   };
 
   const handleActionSelect = (value: string) => {
-    console.log("Action selected:", value);
-    // Add your action logic here
+    if (value === "update") {
+      if (checkedRows.size === 1) {
+        const campaignId = checkedRows.values().next().value;
+        // router.push(`/businesses/campaigns/${campaignId}`);
+      }
+    }
   };
+
+  const handleCheckboxChange = (campaignId: string) => {
+    setCheckedRows((prevCheckedRows) => {
+      const newCheckedRows = new Set(prevCheckedRows);
+      if (newCheckedRows.has(campaignId)) {
+        newCheckedRows.delete(campaignId);
+      } else {
+        newCheckedRows.add(campaignId);
+      }
+      return newCheckedRows;
+    });
+  };
+
+  const handleSeeMore = () => {
+    const nextPage = mobilePage + 1;
+    dispatch(fetchMoreCampaignsRequest({
+      page: nextPage,
+      search: debouncedSearch,
+      per_page: 12
+    }));
+    setMobilePage(nextPage);
+  };
+
   return (
     <div>
-      <div className="py-[13px] bg-white hidden md:block relative">
-        <div
-          className="absolute inset-0 bg-white"
-          style={{ left: "-100vw", right: "-100vw" }}
-        />
-        <div className="max-w-[1428px] mx-auto flex items-center justify-between relative z-10">
-          <div className="text-[18px] leading-[27px] w-[147px]">
-            <SortDropdown onSelect={handleSortSelect} />
-          </div>
-          <div>
-            <TableCardsToggler
-              view={view}
-              setView={setView}
+      <div className="flex justify-between items-center pt-4">
+        <div className="md:hidden flex items-center gap-[7px]">
+          <SearchInputMobile
+            value={searchTerm}
+            onChange={(e) => dispatch(setSearchTerm(e.target.value))}
+            placeholder="Search campaign"
+          />
+          <div className="bg-white rounded-[11px] w-10 h-10  flex items-center justify-center aspect-square">
+            <Image
+              src="/icons/general/sort-1-light.svg"
+              alt="sort"
+              width={24.08}
+              height={14.61}
             />
           </div>
         </div>
-      </div>
-      <div className="md:hidden pt-4 flex items-center gap-[7px]">
-        <SearchInputMobile
-          value={search}
-          onChange={handleSearchChange}
-          placeholder="Search brand"
-        />
-        <div className="bg-white rounded-[11px] w-10 h-10  flex items-center justify-center aspect-square">
-          <Image
-            src="/icons/general/sort-1-light.svg"
-            alt="sort"
-            width={24.08}
-            height={14.61}
-          />
+        <div className="hidden md:block">
+          {/* This will be moved */}
         </div>
       </div>
       <div className="py-5.5">
         <div className="max-w-[1428px] mx-auto">
-          {view === "table" && (
-            <div className="w-[137px] ml-auto mb-5.5 hidden md:block">
-              <ActionDropdown onSelect={handleActionSelect} />
+          <div className="hidden md:flex justify-end items-center mb-5.5 space-x-4">
+            <TableCardsToggler view={view} setView={setView} />
+            <div className="w-auto">
+              <ActionDropdown
+                onSelect={handleActionSelect}
+                showUpdate={checkedRows.size === 1}
+                disabled={checkedRows.size === 0}
+                excludeActions={['delete', 'active', 'inactive']}
+              />
             </div>
-          )}
-          <div className="md:hidden space-y-[7px]">
-            {CampaignsData.length === 0 ? (
-              <div className="text-center py-10 text-gray-500">
-                No records found.
-              </div>
-            ) : (
-              CampaignsData.map((campaign) => {
-                const accountId = getAccountIdFromBrandId(campaign.brandId);
-                return (
-                  <Link
-                    key={campaign.campaignId}
-                    href={`/businesses/accounts/${accountId}/${campaign.brandId}/${campaign.campaignId}`}
-                  >
-                    <CampaignsMobileCard campaign={campaign} />
-                  </Link>
-                );
-              })
-            )}
           </div>
-          <div className="hidden md:block">
-            {view === "table" ? (
-              <>
-                <CampaignsTable
-                  campaigns={currentCampaigns}
-                  getAccountIdFromBrandId={getAccountIdFromBrandId}
-                />
-                {currentCampaigns.length > 0 && (
+          <div className="md:hidden flex justify-end items-center mb-4 space-x-2">
+            <div className="w-auto">
+              <ActionDropdown
+                onSelect={handleActionSelect}
+                showUpdate={checkedRows.size === 1}
+                disabled={checkedRows.size === 0}
+                excludeActions={['delete', 'active', 'inactive']}
+              />
+            </div>
+          </div>
+          {loading && campaigns.length === 0 && <Loader />}
+          {error && <p className="text-red-500">Error: {error}</p>}
+          {!error && (
+            <>
+              <div className="hidden md:block">
+                {view === "table" ? (
+                  <CampaignsTable
+                    campaigns={campaigns}
+                    checkedRows={checkedRows}
+                    onCheckboxChange={handleCheckboxChange}
+                  />
+                ) : (
+                  <>
+                    {campaigns.length === 0 ? (
+                      <div className="bg-white rounded-lg shadow-md text-center py-10 text-gray-500">
+                        No records found.
+                      </div>
+                    ) : (
+                      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                        {campaigns.map((campaign) => (
+                          <CampaignCard
+                            key={campaign.id}
+                            campaign={campaign}
+                            checked={checkedRows.has(campaign.campaign_id)}
+                            onCheckboxChange={() => handleCheckboxChange(campaign.campaign_id)}
+                          />
+                        ))}
+                      </div>
+                    )}
+                  </>
+                )}
+                {loading && campaigns.length > 0 && <div className="text-center py-4"><InlineLoader /></div>}
+                {pagination && campaigns.length > 0 && (
                   <Pagination
-                    totalItems={CampaignsData.length}
-                    itemsPerPage={itemsPerPage}
-                    currentPage={currentPage}
+                    totalItems={pagination.total}
+                    itemsPerPage={pagination.perPage}
+                    currentPage={pagination.currentPage}
                     onPageChange={handlePageChange}
                     onItemsPerPageChange={handleItemsPerPageChange}
                   />
                 )}
-              </>
-            ) : (
-              <>
-                <div className="grid grid-cols-[repeat(auto-fit,340px)] gap-x-[13px] gap-y-[20px] justify-center mb-8">
-                  {CampaignsData.length === 0 ? (
-                    <div className="col-span-full text-center py-10 text-gray-500">
-                      No records found.
-                    </div>
-                  ) : (
-                    CampaignsData.map((campaign) => {
-                      const accountId = getAccountIdFromBrandId(campaign.brandId);
-                      return (
-                        <Link
-                          key={campaign.campaignId}
-                          href={`/businesses/accounts/${accountId}/${campaign.brandId}/${campaign.campaignId}`}
-                        >
-                          <CampaignCard campaign={campaign} />
-                        </Link>
-                      );
-                    })
-                  )}
-                </div>
-              </>
-            )}
-          </div>
+              </div>
+              <div className="md:hidden space-y-[7px]">
+                {campaigns.length === 0 ? (
+                  <div className="text-center py-10 text-gray-500">
+                    No records found.
+                  </div>
+                ) : (
+                  campaigns.map((campaign) => (
+                    <CampaignsMobileCard
+                      key={campaign.id}
+                      campaign={campaign}
+                      checked={checkedRows.has(campaign.campaign_id)}
+                      onCheckboxChange={() => handleCheckboxChange(campaign.campaign_id)}
+                    />
+                  ))
+                )}
+                {loading && campaigns.length > 0 && <div className="text-center py-4"><InlineLoader /></div>}
+                {campaigns.length > 0 && campaigns.length < pagination.total && !loading && (
+                  <div className="text-center font-semibold text-[15px] text-gray-500 my-4 mb-8">
+                    <button
+                      onClick={handleSeeMore}
+                      disabled={loading}
+                      className="disabled:text-gray-400"
+                    >
+                      {loading ? <InlineLoader /> : 'See More'}
+                    </button>
+                  </div>
+                )}
+              </div>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/features/campaigns/CampaignCard.tsx
+++ b/src/components/features/campaigns/CampaignCard.tsx
@@ -2,199 +2,108 @@ import Image from "next/image";
 import { Campaign } from "@/types/entities";
 import { generateColorFromString } from "@/utils/colorGenerator";
 import { getInitials } from "@/utils/text";
+import Checkbox from "@/components/general/CheckBox";
+import Link from "next/link";
 
-export default function CampaignCard({ campaign }: { campaign: Campaign }) {
-  // Map Campaign properties to component state
-  const title = campaign.title;
-  const status =
-    campaign.creatorApprovalType === "Automated" ? "active" : "pending";
-  const logoSrc = campaign.brandLogo; // Use brand logo from Campaign entity
-  const headerSrc = campaign.thumbnailUrl;
+interface CampaignCardProps {
+  campaign: Campaign;
+  checked: boolean;
+  onCheckboxChange: () => void;
+}
 
-  // Helper function to get display name for campaign type
-  const getCampaignTypeDisplay = (campaignType: string) => {
-    switch (campaignType) {
-      case "WalkIn":
-        return "Walk in";
-      case "Delivery":
-        return "Delivery";
-      case "Online":
-        return "Online";
-      case "Exclusive":
-        return "Exclusive";
-      default:
-        return campaignType;
-    }
-  };
+export default function CampaignCard({ campaign, checked, onCheckboxChange }: CampaignCardProps) {
+  const status = campaign.offer_status;
+  const logoSrc = campaign.venue.logo;
+  const headerSrc = campaign.banner_image;
+  const isActive = status !== "Draft";
 
-  const mode: "Walk in" | "Delivery" | "Online" | "Exclusive" =
-    campaign.campaignType === "WalkIn"
-      ? "Walk in"
-      : campaign.campaignType === "Delivery"
-      ? "Delivery"
-      : campaign.campaignType === "Online"
-      ? "Online"
-      : "Exclusive";
+  // TODO: Replace with the actual base URL from environment variables
+  const IMAGE_BASE_URL = "https://dev-partners.alist.ae/";
 
-  // const barter = campaign.offerType === "Barter";
-  const daysRemaining = campaign.advancedVisibility.duration;
-
-  const isActive = status === "active";
-
-  // Determine icons based on status and mode
-  const getModeIcon = () => {
-    if (mode === "Walk in") {
-      return isActive
-        ? "/icons/campaign/card/walk-approved.svg"
-        : "/icons/campaign/card/walk-pending-light.svg";
-    } else if (mode === "Delivery") {
-      return isActive
-        ? "/icons/campaign/card/delivery-approved.svg"
-        : "/icons/campaign/card/delivery-pending-light.svg";
-    } else {
-      // For Online and Exclusive, use delivery icon as fallback
-      return isActive
-        ? "/icons/campaign/card/delivery-approved.svg"
-        : "/icons/campaign/card/delivery-pending-light.svg";
-    }
-  };
-
-  const getBarterIcon = () => {
-    return isActive
-      ? "/icons/campaign/card/barter-approved.svg"
-      : "/icons/campaign/card/barter-pending-light.svg";
+  const handleWrapperClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
   };
 
   return (
-    <article className="w-full  bg-white rounded-[13px] overflow-hidden">
-      <div className="h-[90px] w-full relative bg-[#E1E1E1]">
-        {headerSrc && (
-          <Image
-            src={headerSrc}
-            alt={`${title} header`}
-            fill
-            className="object-cover"
+    <Link href={`/businesses/campaigns/${campaign.campaign_id}`} className="block cursor-pointer">
+      <article className="w-full bg-white rounded-[13px] overflow-hidden relative">
+        <div onClick={handleWrapperClick} className="absolute top-2 right-2 z-10">
+          <Checkbox
+            checked={checked}
+            onChange={onCheckboxChange}
+            onClick={(e) => e.stopPropagation()}
           />
-        )}
-        <div className="w-[90px] h-[90px] absolute top-[39px] left-[24px] bg-white rounded-full border-5 border-[#E1E1E1] flex items-center justify-center overflow-hidden">
-          {logoSrc ? (
+        </div>
+        <div className="h-[90px] w-full relative bg-[#E1E1E1]">
+          {headerSrc && (
             <Image
-              src={logoSrc}
-              alt="Brand logo"
+              src={`${IMAGE_BASE_URL}storage/uploads/users/influencers/offers/${headerSrc}`}
+              alt={`${campaign.offer_title} header`}
               fill
-              className="object-cover rounded-full aspect-square"
+              className="object-cover"
             />
-          ) : (
-            <div
-              className="h-full w-full flex items-center justify-center"
-              style={{
-                backgroundColor: generateColorFromString(campaign.brandName),
-              }}
-            >
-              <span className="text-white text-3xl font-semibold">
-                {getInitials(campaign.brandName)}
-              </span>
-            </div>
           )}
-        </div>
-      </div>
-
-      <div className="pt-[35px] pb-[15px] px-[21px]  ">
-        <div className="">
-          <h3 className="text-[15px] font-medium leading-[23px] text-[#4F4F4F]">
-            {title}
-          </h3>
-        </div>
-        <div className="flex items-center justify-between mb-[15px]">
-          <p className="text-[13px] text-[#414141] leading-[20px]">
-            By {campaign.brandName}
-          </p>
-          {isActive ? (
-            <div className="flex gap-[4.5px] items-center">
-              {" "}
+          <div className="w-[90px] h-[90px] absolute top-[39px] left-[24px] bg-white rounded-full border-5 border-[#E1E1E1] flex items-center justify-center overflow-hidden">
+            {logoSrc ? (
               <Image
-                src="/icons/campaign/card/active-light.svg"
-                alt="pending"
-                width={11.6}
-                height={11.6}
+                src={`${IMAGE_BASE_URL}storage/uploads/venues/logo/${logoSrc}`}
+                alt="Brand logo"
+                fill
+                className="object-cover rounded-full aspect-square"
               />
-              <p className="text-[13px] text-[#787878] leading-[20px]">
-                Active
-              </p>
-            </div>
-          ) : (
-            <div className="flex gap-[4.5px] items-center">
-              <Image
-                src="/icons/campaign/card/pending-light.svg"
-                alt="pending"
-                width={11.6}
-                height={11.6}
-              />
-              <p className="text-[13px] text-[#787878] leading-[20px]">
-                Pending
-              </p>
-            </div>
-          )}
-        </div>
-
-        {/* Separator line */}
-        <hr className="border-[#F2F2F2] mb-[15px]" />
-
-        {/* Icon grid */}
-        <div className="grid grid-cols-3 gap-[9px] mb-[13px] ">
-          <div className="aspect-square flex flex-col justify-center items-center gap-2 rounded-[11px] bg-white shadow-[0_0_2px_rgba(0,0,0,0.16)]">
-            <div className="h-[30.65px] flex items-center justify-center">
-              <Image
-                src={getModeIcon()}
-                alt={mode}
-                width={mode === "Walk in" ? 18.04 : 31.87}
-                height={mode === "Walk in" ? 29.65 : 30.65}
-              />
-            </div>
-            <span className="text-[12px] text-[#414141] leading-[20px]">
-              {getCampaignTypeDisplay(campaign.campaignType)}
-            </span>
-          </div>
-
-          <div className="aspect-square flex flex-col justify-center items-center gap-2 rounded-[11px] bg-white shadow-[0_0_2px_rgba(0,0,0,0.16)]">
-            <div className="h-[30.65px] flex items-center justify-center">
-              <Image
-                src={getBarterIcon()}
-                alt="Barter"
-                width={24}
-                height={25.83}
-              />
-            </div>
-            <span className="text-[12px] text-[#414141] font-medium">
-              {campaign.offerType}
-            </span>
-          </div>
-          <div className="aspect-square flex flex-col justify-center items-center gap-2 rounded-[11px] bg-white shadow-[0_0_2px_rgba(0,0,0,0.16)]">
-            <div className="h-[30.65px] flex items-center justify-center">
-              <span
-                className={`text-[21px] font-bold leading-[31px] ${
-                  isActive ? "text-[#00A4B6]" : "text-[#505050]"
-                }`}
+            ) : (
+              <div
+                className="h-full w-full flex items-center justify-center"
+                style={{
+                  backgroundColor: generateColorFromString(campaign.venue.venue_title),
+                }}
               >
-                {typeof daysRemaining === "number" ? daysRemaining : "N/A"}
-              </span>
-            </div>
-            <span className="text-[12px] text-[#414141] font-medium">
-              {campaign.advancedVisibility.unit}
-            </span>
+                <span className="text-white text-3xl font-semibold">
+                  {getInitials(campaign.venue.venue_title)}
+                </span>
+              </div>
+            )}
           </div>
         </div>
 
-        <div className="flex gap-[9px]">
-          <button className="flex-1 bg-[#00A4B6] text-[15px] text-white py-[9px] rounded-[11px] font-medium leading-[23px]">
-            Edit
-          </button>
-
-          <button className="flex-1 bg-[#787878] text-[15px]  text-white py-[9px] rounded-[11px] font-medium leading-[23px]">
-            Remove
-          </button>
+        <div className="pt-[55px] pb-[15px] px-[21px]">
+          <div className="mb-[15px]">
+            <h3 className="text-[15px] font-medium leading-[23px] text-[#4F4F4F] truncate">
+              {campaign.offer_title}
+            </h3>
+          </div>
+          <div className="flex items-center justify-between mb-[15px]">
+            <p className="text-[13px] text-[#414141] leading-[20px] truncate">
+              By {campaign.venue.venue_title}
+            </p>
+            {isActive ? (
+              <div className="flex gap-[4.5px] items-center">
+                <Image
+                  src="/icons/campaign/card/active-light.svg"
+                  alt="active"
+                  width={11.6}
+                  height={11.6}
+                />
+                <p className="text-[13px] text-[#787878] leading-[20px]">
+                  Active
+                </p>
+              </div>
+            ) : (
+              <div className="flex gap-[4.5px] items-center">
+                <Image
+                  src="/icons/campaign/card/pending-light.svg"
+                  alt="pending"
+                  width={11.6}
+                  height={11.6}
+                />
+                <p className="text-[13px] text-[#787878] leading-[20px]">
+                  Draft
+                </p>
+              </div>
+            )}
+          </div>
         </div>
-      </div>
-    </article>
+      </article>
+    </Link>
   );
 }

--- a/src/components/features/campaigns/CampaignsMobileCard.tsx
+++ b/src/components/features/campaigns/CampaignsMobileCard.tsx
@@ -1,0 +1,70 @@
+import Image from "next/image";
+import { Campaign } from "@/types/entities";
+import Link from "next/link";
+import Checkbox from "@/components/general/CheckBox";
+import { generateColorFromString } from "@/utils/colorGenerator";
+import { getInitials } from "@/utils/text";
+
+interface CampaignsMobileCardProps {
+  campaign: Campaign;
+  checked: boolean;
+  onCheckboxChange: () => void;
+}
+
+export default function CampaignsMobileCard({
+  campaign,
+  checked,
+  onCheckboxChange,
+}: CampaignsMobileCardProps) {
+  // TODO: Replace with the actual base URL from environment variables
+  const IMAGE_BASE_URL = "https://dev-partners.alist.ae/";
+
+  const handleWrapperClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <div className="bg-white rounded-[13px] p-3.5 relative">
+      <div onClick={handleWrapperClick} className="absolute top-4 right-4 z-10">
+        <Checkbox
+          checked={checked}
+          onChange={onCheckboxChange}
+        />
+      </div>
+      <Link href={`/businesses/campaigns/${campaign.campaign_id}`} className="block cursor-pointer">
+        <div className="flex gap-5 items-center">
+          <div className="relative w-[86.31px] h-[86.31px] rounded-[10px] overflow-hidden flex-shrink-0">
+            {campaign.banner_image ? (
+              <Image
+                src={`${IMAGE_BASE_URL}storage/uploads/users/influencers/offers/${campaign.banner_image}`}
+                alt={campaign.offer_title}
+                fill
+                className="object-cover"
+              />
+            ) : (
+              <div
+                className="w-full h-full flex items-center justify-center"
+                style={{ backgroundColor: generateColorFromString(campaign.offer_title) }}
+              >
+                <span className="text-white text-3xl font-semibold">{getInitials(campaign.offer_title)}</span>
+              </div>
+            )}
+          </div>
+          <div className="flex-1 min-w-0">
+            <h3 className="text-[15px] font-semibold leading-[1.5] text-[#4F4F4F] mb-1.5 truncate">
+              {campaign.offer_title}
+            </h3>
+            <p className="text-[13px] font-medium text-[#414141] leading-[1.5] mb-2 truncate">
+              {campaign.venue.venue_title}
+            </p>
+            <div className="flex items-center justify-between text-[13px] text-[#757575]">
+              <span>{campaign.start_date}</span>
+              <span>-</span>
+              <span>{campaign.end_date}</span>
+            </div>
+          </div>
+        </div>
+      </Link>
+    </div>
+  );
+}

--- a/src/components/features/campaigns/CampaignsTable.tsx
+++ b/src/components/features/campaigns/CampaignsTable.tsx
@@ -3,52 +3,25 @@
 import Checkbox from "@/components/general/CheckBox";
 import Image from "next/image";
 import { Campaign } from "@/types/entities";
-import { useState } from "react";
 import Link from "next/link";
 
 interface CampaignsTableProps {
   campaigns: Campaign[];
-  getAccountIdFromBrandId: (brandId: string) => string;
+  checkedRows: Set<string>;
+  onCheckboxChange: (campaignId: string) => void;
 }
 
 export default function CampaignsTable({
   campaigns,
-  getAccountIdFromBrandId,
+  checkedRows,
+  onCheckboxChange,
 }: CampaignsTableProps) {
-  const [checkedRows, setCheckedRows] = useState<Set<string>>(new Set());
-
-  const handleCheckboxChange = (campaignId: string) => {
-    const newCheckedRows = new Set(checkedRows);
-    if (newCheckedRows.has(campaignId)) {
-      newCheckedRows.delete(campaignId);
-    } else {
-      newCheckedRows.add(campaignId);
-    }
-    setCheckedRows(newCheckedRows);
-  };
-
-  // Helper function to get display name for campaign type
-  const getCampaignTypeDisplay = (campaignType: string) => {
-    switch (campaignType) {
-      case "WalkIn":
-        return "Walk in";
-      case "Delivery":
-        return "Delivery";
-      case "Online":
-        return "Online";
-      case "Exclusive":
-        return "Exclusive";
-      default:
-        return campaignType;
-    }
-  };
-
-  // Helper function to get campaign status (using creatorApprovalType as proxy)
   const getCampaignStatus = (campaign: Campaign) => {
-    // For now, using creatorApprovalType as status
-    // In a real app, you'd have a separate status field
-    return campaign.creatorApprovalType === "Manual" ? "Pending" : "Approved";
+    return campaign.offer_status;
   };
+
+  // TODO: Replace with the actual base URL from environment variables
+  const IMAGE_BASE_URL = "https://dev-partners.alist.ae/";
 
   return (
     <div className="overflow-x-auto">
@@ -71,13 +44,13 @@ export default function CampaignsTable({
               scope="col"
               className="px-6 pt-2.5 pb-4 text-left text-lg font-medium text-[#4F4F4F] whitespace-nowrap"
             >
-              Campaign type
+              Start Date
             </th>
             <th
               scope="col"
               className="px-6 pt-2.5 pb-4 text-left text-lg font-medium text-[#4F4F4F] whitespace-nowrap"
             >
-              Offer type
+              End Date
             </th>
             <th
               scope="col"
@@ -101,134 +74,85 @@ export default function CampaignsTable({
         </thead>
 
         <tbody className="bg-white">
-          {campaigns.map((campaign) => {
-            const accountId = getAccountIdFromBrandId(campaign.brandId);
-            return (
-              <tr key={campaign.campaignId} className="odd:bg-[#F8F8F8]">
-                <td className="px-4.75 py-2.5 whitespace-nowrap">
-                  <div className="flex items-center">
-                    <Checkbox
-                      checked={checkedRows.has(campaign.campaignId)}
-                      onChange={() => handleCheckboxChange(campaign.campaignId)}
-                    />
-                    <Link
-                      href={`/businesses/accounts/${accountId}/${campaign.brandId}/${campaign.campaignId}`}
-                      className="flex items-center ml-3 cursor-pointer"
-                    >
-                      <div className="h-[33px] w-[70px] rounded-[6px] overflow-hidden relative flex-shrink-0">
-                        <Image
-                          src={campaign.thumbnailUrl}
-                          alt={campaign.title}
-                          fill
-                          className="object-cover"
-                        />
-                      </div>
-                      <span
-                        className={`ml-3 text-[#4F4F4F] ${
-                          checkedRows.has(campaign.campaignId)
-                            ? "font-semibold"
-                            : ""
-                        }`}
-                      >
-                        {campaign.title}
-                      </span>
-                    </Link>
-                  </div>
-                </td>
-                <td className="px-6 py-2.5 whitespace-nowrap text-[15px] text-[#4F4F4F]">
-                  {campaign.title}
-                </td>
-                <td className="px-6 py-2.5 whitespace-nowrap text-[13px] text-center">
-                  <div
-                    className={`w-[98px] max-w-[98px] truncate px-3 py-1 rounded-full text-white inline-flex items-center justify-center gap-1.5 ${
-                      campaign.campaignType === "WalkIn"
-                        ? "bg-[#00A4B6]"
-                        : campaign.campaignType === "Delivery"
-                        ? "bg-[#FF9900]"
-                        : campaign.campaignType === "Online"
-                        ? "bg-[#15A1FF]"
-                        : campaign.campaignType === "Exclusive"
-                        ? "bg-[#B400FF]"
-                        : "bg-[#636363]"
-                    }`}
-                  >
-                    {campaign.campaignType === "WalkIn" && (
-                      <Image
-                        src="/icons/general/walk-in-1.svg"
-                        alt="walk in"
-                        width={10.88}
-                        height={17.88}
-                      />
-                    )}
-                    {campaign.campaignType === "Delivery" && (
-                      <Image
-                        src="/icons/general/delivery-1.svg"
-                        alt="delivery"
-                        width={17}
-                        height={16.54}
-                      />
-                    )}
-                    {campaign.campaignType === "Online" && (
-                      <Image
-                        src="/icons/general/online-1.svg"
-                        alt="online"
-                        width={14.48}
-                        height={14.48}
-                      />
-                    )}
-                    {campaign.campaignType === "Exclusive" && (
-                      <Image
-                        src="/icons/general/exclusive-1.svg"
-                        alt="exclusive"
-                        width={15.35}
-                        height={13.24}
-                      />
-                    )}
-                    <span>{getCampaignTypeDisplay(campaign.campaignType)}</span>
-                  </div>
-                </td>
-                <td className="px-6 py-2.5 whitespace-nowrap text-[15px] text-[#4F4F4F]">
-                  {campaign.offerType}
-                </td>
-                <td className="px-6 py-2.5 whitespace-nowrap text-[13px] text-center">
-                  <div
-                    className={`w-[98px] px-4.25 py-1 rounded-full text-white ${
-                      getCampaignStatus(campaign) === "Pending"
-                        ? "bg-[#636363]"
-                        : "bg-[#00CC86]"
-                    }`}
-                  >
-                    {getCampaignStatus(campaign)}
-                  </div>
-                </td>
-                <td className="px-6 py-2.5 whitespace-nowrap text-[13px] text-center">
-                  <button className="w-[98px] px-4.25 py-1 bg-[#00A4B6] text-white rounded-full flex justify-center items-center gap-2">
-                    <div>Copy link</div>
-                    <Image
-                      src={"/icons/general/copy-white-1.svg"}
-                      alt="copy"
-                      width={14.48}
-                      height={14.48}
-                    />
-                  </button>
-                </td>
-                <td className="px-6 py-2.5 whitespace-nowrap text-[13px] text-center">
+          {campaigns.map((campaign) => (
+            <tr key={campaign.id} className="odd:bg-[#F8F8F8]">
+              <td className="px-4.75 py-2.5 whitespace-nowrap">
+                <div className="flex items-center">
+                  <Checkbox
+                    checked={checkedRows.has(campaign.campaign_id)}
+                    onChange={() => onCheckboxChange(campaign.campaign_id)}
+                  />
                   <Link
-                    href={`/businesses/accounts/${accountId}/${campaign.brandId}/${campaign.campaignId}`}
-                    className="w-[98px] px-4.25 py-1 bg-[#00A4B6] text-white rounded-full flex justify-center items-center gap-2 cursor-pointer hover:opacity-80 transition-opacity"
+                    href={`/businesses/campaigns/${campaign.campaign_id}`}
+                    className="flex items-center ml-3 cursor-pointer"
                   >
-                    <div>View</div>
-                    <Image
-                      src={"/icons/general/view-1.svg"}
-                      alt="view"
-                      width={14.48}
-                      height={14.48}
-                    />
+                    <div className="h-[33px] w-[70px] rounded-[6px] overflow-hidden relative flex-shrink-0">
+                      <Image
+                        src={`${IMAGE_BASE_URL}storage/uploads/users/influencers/offers/${campaign.banner_image}`}
+                        alt={campaign.offer_title}
+                        fill
+                        className="object-cover"
+                      />
+                    </div>
+                    <span
+                      className={`ml-3 text-[#4F4F4F] ${
+                        checkedRows.has(campaign.campaign_id)
+                          ? "font-semibold"
+                          : ""
+                      }`}
+                    >
+                      {campaign.offer_title}
+                    </span>
                   </Link>
-                </td>
-              </tr>
-            );
-          })}
+                </div>
+              </td>
+              <td className="px-6 py-2.5 whitespace-nowrap text-[15px] text-[#4F4F4F]">
+                {campaign.venue.venue_title}
+              </td>
+              <td className="px-6 py-2.5 whitespace-nowrap text-[15px] text-[#4F4F4F]">
+                {campaign.start_date}
+              </td>
+              <td className="px-6 py-2.5 whitespace-nowrap text-[15px] text-[#4F4F4F]">
+                {campaign.end_date}
+              </td>
+              <td className="px-6 py-2.5 whitespace-nowrap text-[13px] text-center">
+                <div
+                  className={`w-[98px] px-4.25 py-1 rounded-full text-white ${
+                    getCampaignStatus(campaign) === "Draft"
+                      ? "bg-[#636363]"
+                      : "bg-[#00CC86]"
+                  }`}
+                >
+                  {getCampaignStatus(campaign)}
+                </div>
+              </td>
+              <td className="px-6 py-2.5 whitespace-nowrap text-[13px] text-center">
+                <button className="w-[98px] px-4.25 py-1 bg-[#00A4B6] text-white rounded-full flex justify-center items-center gap-2">
+                  <div>Copy link</div>
+                  <Image
+                    src={"/icons/general/copy-white-1.svg"}
+                    alt="copy"
+                    width={14.48}
+                    height={14.48}
+                  />
+                </button>
+              </td>
+              <td className="px-6 py-2.5 whitespace-nowrap text-[13px] text-center">
+                <Link
+                  href={`/businesses/campaigns/${campaign.campaign_id}`}
+                  className="w-[98px] px-4.25 py-1 bg-[#00A4B6] text-white rounded-full flex justify-center items-center gap-2 cursor-pointer hover:opacity-80 transition-opacity"
+                >
+                  <div>View</div>
+                  <Image
+                    src={"/icons/general/view-1.svg"}
+                    alt="view"
+                    width={14.48}
+                    height={14.48}
+                  />
+                </Link>
+              </td>
+            </tr>
+          ))}
         </tbody>
       </table>
     </div>

--- a/src/store/campaign/campaignSaga.ts
+++ b/src/store/campaign/campaignSaga.ts
@@ -1,0 +1,113 @@
+import { call, put, takeLatest, all } from 'redux-saga/effects';
+import toast from 'react-hot-toast';
+import { postData } from '@/services/commonService';
+import {
+  fetchCampaignsRequest,
+  fetchCampaignsSuccess,
+  fetchCampaignsFailure,
+  fetchMoreCampaignsRequest,
+  fetchMoreCampaignsSuccess,
+  fetchMoreCampaignsFailure,
+} from './campaignSlice';
+import { Campaign } from '@/types/entities';
+
+type ApiError = {
+  success: false;
+  message: string;
+  venues: any;
+};
+
+type FetchCampaignsSuccessResponse = {
+  success: boolean;
+  message: string;
+  venues: {
+    data: Campaign[];
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+  };
+};
+
+function* handleFetchCampaigns(action: ReturnType<typeof fetchCampaignsRequest>) {
+  try {
+    const { page, ...bodyPayload } = action.payload;
+    let endpoint = '/api/campaigns';
+    if (page) {
+      endpoint = `${endpoint}?page=${page}`;
+    }
+
+    const response: FetchCampaignsSuccessResponse | ApiError = yield call(postData, endpoint, bodyPayload);
+
+    if (response.success) {
+      const { data, current_page, last_page, per_page, total } = (response as FetchCampaignsSuccessResponse).venues;
+
+      yield put(fetchCampaignsSuccess({
+        campaigns: data,
+        pagination: {
+          currentPage: current_page,
+          lastPage: last_page,
+          perPage: per_page,
+          total: total,
+        },
+      }));
+    } else {
+      const errorResponse = response as ApiError;
+      const errorMessage = errorResponse.message || 'Failed to fetch campaigns';
+      yield put(fetchCampaignsFailure(errorMessage));
+      toast.error(errorMessage);
+    }
+  } catch (error) {
+    const err = error as Error;
+    const errorMessage = err.message || 'An unknown error occurred';
+    yield put(fetchCampaignsFailure(errorMessage));
+    toast.error(errorMessage);
+  }
+}
+
+function* handleFetchMoreCampaigns(action: ReturnType<typeof fetchMoreCampaignsRequest>) {
+  try {
+    const { page, ...bodyPayload } = action.payload;
+    let endpoint = '/api/campaigns';
+    if (page) {
+      endpoint = `${endpoint}?page=${page}`;
+    }
+
+    const response: FetchCampaignsSuccessResponse | ApiError = yield call(postData, endpoint, bodyPayload);
+
+    if (response.success) {
+      const { data, current_page, last_page, per_page, total } = (response as FetchCampaignsSuccessResponse).venues;
+
+      yield put(fetchMoreCampaignsSuccess({
+        campaigns: data,
+        pagination: {
+          currentPage: current_page,
+          lastPage: last_page,
+          perPage: per_page,
+          total: total,
+        },
+      }));
+    } else {
+      const errorResponse = response as ApiError;
+      const errorMessage = errorResponse.message || 'Failed to fetch more campaigns';
+      yield put(fetchMoreCampaignsFailure(errorMessage));
+      toast.error(errorMessage);
+    }
+  } catch (error) {
+    const err = error as Error;
+    const errorMessage = err.message || 'An unknown error occurred';
+    yield put(fetchMoreCampaignsFailure(errorMessage));
+    toast.error(errorMessage);
+  }
+}
+
+function* watchCampaign() {
+  yield takeLatest(fetchCampaignsRequest.type, handleFetchCampaigns);
+  yield takeLatest(fetchMoreCampaignsRequest.type, handleFetchMoreCampaigns);
+}
+
+export default function* campaignSaga() {
+  yield all([
+    watchCampaign(),
+  ]);
+}

--- a/src/store/campaign/campaignSlice.ts
+++ b/src/store/campaign/campaignSlice.ts
@@ -1,0 +1,68 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { Campaign } from '@/types/entities';
+import { PaginationState } from '@/types/api';
+
+interface CampaignState {
+  campaigns: Campaign[];
+  campaign: Campaign | null;
+  pagination: PaginationState;
+  loading: boolean;
+  error: string | null;
+}
+
+const initialState: CampaignState = {
+  campaigns: [],
+  campaign: null,
+  pagination: {
+    currentPage: 1,
+    lastPage: 1,
+    perPage: 10,
+    total: 0,
+  },
+  loading: false,
+  error: null,
+};
+
+const campaignSlice = createSlice({
+  name: 'campaign',
+  initialState,
+  reducers: {
+    fetchCampaignsRequest: (state, action: PayloadAction<{ page: number; per_page: number; search?: string }>) => {
+      state.loading = true;
+      state.error = null;
+    },
+    fetchCampaignsSuccess: (state, action: PayloadAction<{ campaigns: Campaign[]; pagination: PaginationState }>) => {
+      state.loading = false;
+      state.campaigns = action.payload.campaigns;
+      state.pagination = action.payload.pagination;
+    },
+    fetchCampaignsFailure: (state, action: PayloadAction<string>) => {
+      state.loading = false;
+      state.error = action.payload;
+    },
+    fetchMoreCampaignsRequest: (state, action: PayloadAction<{ page: number; per_page: number; search?: string }>) => {
+      state.loading = true;
+      state.error = null;
+    },
+    fetchMoreCampaignsSuccess: (state, action: PayloadAction<{ campaigns: Campaign[]; pagination: PaginationState }>) => {
+      state.loading = false;
+      state.campaigns = [...state.campaigns, ...action.payload.campaigns];
+      state.pagination = action.payload.pagination;
+    },
+    fetchMoreCampaignsFailure: (state, action: PayloadAction<string>) => {
+      state.loading = false;
+      state.error = action.payload;
+    },
+  },
+});
+
+export const {
+  fetchCampaignsRequest,
+  fetchCampaignsSuccess,
+  fetchCampaignsFailure,
+  fetchMoreCampaignsRequest,
+  fetchMoreCampaignsSuccess,
+  fetchMoreCampaignsFailure,
+} = campaignSlice.actions;
+
+export default campaignSlice.reducer;

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -2,6 +2,7 @@ import { combineReducers } from '@reduxjs/toolkit';
 import authReducer from './auth/authSlice';
 import accountReducer from './account/accountSlice';
 import brandReducer from './brand/brandSlice';
+import campaignReducer from './campaign/campaignSlice';
 import searchReducer from './search/searchSlice';
 import commonReducer from './common/commonSlice';
 
@@ -9,6 +10,7 @@ const rootReducer = combineReducers({
   auth: authReducer,
   account: accountReducer,
   brand: brandReducer,
+  campaign: campaignReducer,
   search: searchReducer,
   common: commonReducer,
 });

--- a/src/store/rootSaga.ts
+++ b/src/store/rootSaga.ts
@@ -2,6 +2,7 @@ import { all } from 'redux-saga/effects';
 import authSaga from './auth/authSaga';
 import accountSaga from './account/accountSaga';
 import brandSaga from './brand/brandSaga';
+import campaignSaga from './campaign/campaignSaga';
 import commonSaga from './common/commonSaga';
 
 export default function* rootSaga() {
@@ -9,6 +10,7 @@ export default function* rootSaga() {
     authSaga(),
     accountSaga(),
     brandSaga(),
+    campaignSaga(),
     commonSaga(),
   ]);
 }

--- a/src/types/entities/campaign.ts
+++ b/src/types/entities/campaign.ts
@@ -1,162 +1,152 @@
-import { CampaignPost } from './campaignPost';
+export interface Venue {
+  id: number;
+  account_id: string | null;
+  venue_title: string;
+  company_name: string | null;
+  logo: string | null;
+  banner: string | null;
+  phone_number: string | null;
+  email_address: string | null;
+  trade_license: string | null;
+  trade_license_expiry: string | null;
+  vat_certificate: string | null;
+  address: string | null;
+  latitude: string | null;
+  longitude: string | null;
+  instagram_handle: string | null;
+  website_url: string | null;
+  status: string | null;
+  contact_person_name: string | null;
+  contact_person_email: string | null;
+  contact_person_phone: string | null;
+  city: string | null;
+  state: string | null;
+  country: string | null;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+  deleted_by: string | null;
+  updated_by: number | null;
+  created_by: number | null;
+  account_manager: number | null;
+  brand_id: number;
+  commission_rate: string;
+  auto_payment: number;
+  auto_payment_card_id: number | null;
+  auto_payment_day: string | null;
+  auto_payment_fail_notif: number;
+  industry_id: number;
+  sub_industry_id: number | null;
+  notif_new_offer: number;
+  notif_new_review: number;
+  notif_offer_no_show: number;
+  notif_offer_cancel: number;
+  notif_offer_remind: number;
+  notif_monthly_report: number;
+  contact_person_is_alist: number;
+  contact_person_ref_id: number | null;
+  is_all_outlet_same: number;
+  is_contract_signed: number;
+  zomoato_url: string | null;
+  talabat_url: string | null;
+  deliveroo_url: string | null;
+  google_map_url: string | null;
+  other_map_url: string | null;
+  account_type: string;
+  sub_account_type: string | null;
+  is_physical_signed: number;
+  is_digital_signed: number;
+  is_paid: number;
+  business_location: string | null;
+  venue_code: string;
+  start_date: string | null;
+  end_date: string | null;
+  contract_period: string | null;
+  payment_terms: string | null;
+  other_venue_documents: string | null;
+  is_outlets_feature: number;
+  is_auto_renewal: number;
+  renewal_date: string | null;
+  renewal_price: string | null;
+  renewal_period: string | null;
+  is_master_venue: number;
+  master_venue_id: number | null;
+  is_sub_venue: number;
+  is_old_venue: number;
+  is_new_venue: number;
+}
 
-// Campaign type enums
-export type CampaignType = "WalkIn" | "Delivery" | "Online" | "Exclusive";
-export type OfferType = "Barter" | "Paid" | "BarterAndPaid";
-export type TimeUnit = "Days" | "Hours";
-export type ChannelType =
-  | "InstagramStories"
-  | "GoogleReviews"
-  | "InstagramPosts"
-  | "TikTokVideos"
-  | "YouTubeVideos"
-  | "BlogPosts";
-export type AudienceDefinition = "Specific" | "Broad";
-export type CreatorApprovalType = "Automated" | "Manual";
-export type CreatorStatusFilter =
-  | "InstagramVerified"
-  | "TikTokVerified"
-  | "YouTubeVerified"
-  | "SnapchatVerified";
-
-// Payment arrangement type
-export type PaymentArrangement = {
-  arrangement: OfferType;
-  currency: string;
-  amount: number;
-};
-
-// Channel configuration type
-export type ChannelConfig = {
-  type: ChannelType;
-  config: Record<string, unknown>; // Flexible config object
-  url: string;
-};
-
-// Age range type
-export type AgeRange = {
-  min: number;
-  max: number;
-};
-
-// Followers tier range type (can be string or object)
-export type FollowersTierRange = string | { min: number; max: number };
-
-// Advanced visibility type
-export type AdvancedVisibility = {
-  duration: number;
-  unit: TimeUnit;
-};
-
-// Campaign stats type
-export type CampaignStats = {
-  creators: number | string;
-  impressions: number | string;
-  reach: number | string;
-  posts: number | string;
-  reviews: number | string;
-};
-
-// Campaign details type
-export type CampaignDetails = {
-  walkIn: string;
-  barter: string;
-  price: string;
-  approval: string;
-  restricted: string;
-  date: string;
-};
-
-// Campaign guideline type
-export type CampaignGuideline = {
-  platform: string;
-  platformIcon: string;
-  requirements: string;
-  rules: {
-    label: string;
-    value: string;
-    highlight?: string;
-  }[];
-};
-
-// Campaign plan type
-export type CampaignPlan = {
-  planName: string;
-  planType: string;
-  nextBillAmount: number;
-  nextBillCurrency: string;
-  nextBillDate: string;
-  paymentDate: string;
-  cardType: string;
-  cardIcon: string;
-  cardEnding: string;
-};
-
-// Campaign post type - moved to ./campaignPost.ts to avoid naming conflict
-
-// Main Campaign type - Expanded version
-export type Campaign = {
-  // Primary identifiers
-  campaignId: string; // UUID / string
-  brandId: string; // UUID / string (FK)
-  subscriptionId: string; // UUID / string (FK)
-
-  // Basic campaign info
-  title: string;
-  thumbnailUrl: string;
-  campaignType: CampaignType;
-  offerType: OfferType;
-
-  // Brand information (derived from brandId)
-  brandLogo: string;
-  brandName: string;
-
-  // Payment details
-  payments: PaymentArrangement[];
-
-  // Campaign content
-  offerDescription: string;
-  advancedVisibility: AdvancedVisibility;
-  campaignMessage: string;
-
-  // Channels configuration
-  channels: ChannelConfig[];
-
-  // Campaign rules
-  rulesAndGuidelines: string;
-
-  // Audience targeting
-  audienceDefinition: AudienceDefinition;
-  potentialReach: number;
-  ageRange: AgeRange;
-  excludedLanguages: string[];
-  followersTierRange: FollowersTierRange;
-  influencerTags: string[];
-  creatorStatusFilters: CreatorStatusFilter[];
-
-  // Creator approval
-  creatorApprovalType: CreatorApprovalType;
-
-  // Voucher details
-  voucherValue: number;
-  voucherCurrency: string;
-
-  // Campaign statistics
-  campaignStats: CampaignStats;
-
-  // Campaign details
-  campaignDetails: CampaignDetails;
-
-  // Campaign guidelines
-  campaignGuidelines: CampaignGuideline[];
-
-  // Campaign plan
-  campaignPlan: CampaignPlan;
-
-  // Campaign posts
-  campaignPosts?: CampaignPost[];
-
-  // Timestamps
-  createdAt: Date;
-  updatedAt: Date;
-};
+export interface Campaign {
+  id: number;
+  offer_title: string;
+  restaurant_name: number;
+  campaign_id: string;
+  social_media_id: number;
+  banner_image: string;
+  start_date: string;
+  end_date: string;
+  offer_usage: number;
+  description: string;
+  email_text: string;
+  credibility_range: string | null;
+  date_valid_text: string;
+  rule_1: string;
+  rule_2: string;
+  rule_3: string;
+  review_url: string | null;
+  restaurant_website: string | null;
+  whatsapp_no: string | null;
+  amount: string;
+  currency_id: number;
+  instagram_followers: string;
+  account_status: string;
+  offer_status: string;
+  offer_notify: number;
+  minimum_user_count: number | null;
+  no_of_tables: number | null;
+  offer_gender: string;
+  user_types: string;
+  is_offer_blogger: number;
+  is_offer_instagram_verified: number;
+  is_offer_special: number;
+  is_offer_is_prive: number;
+  max_age: number;
+  min_age: number;
+  influencer_types: string;
+  created_at: string;
+  updated_at: string;
+  reminder_custom_date: string;
+  skip_invitation: number;
+  notification_text: string | null;
+  start_offer_block: string | null;
+  end_offer_block: string | null;
+  is_dedicated: number;
+  dedicated_offer_id: number | null;
+  venue_offer_banner: number;
+  custom_btn_url: string | null;
+  custom_btn_icon: string | null;
+  custom_btn_title: string | null;
+  insight_required: number;
+  is_groupX: number;
+  offer_location: string | null;
+  location_country_id: number | null;
+  calendar_custom_days: number;
+  dress_code: string | null;
+  group_id: number | null;
+  mobile_redemption_title: string | null;
+  mobile_redemption_text: string | null;
+  schedule_publish_time: string | null;
+  phone_campaign_message: string | null;
+  phone_campaign_mentions: string | null;
+  phone_review_text: string | null;
+  phone_review_comments: string | null;
+  offer_start_time: string | null;
+  offer_end_time: string | null;
+  offer_display_start_time: string;
+  offer_display_end_time: string;
+  offer_available_start_date: string | null;
+  offer_available_end_date: string | null;
+  skip_stories: number;
+  is_offer_dummy: number;
+  venue: Venue;
+}


### PR DESCRIPTION
This commit introduces a new campaign list page that fetches and displays data from the `/api/campaigns` endpoint.

The page includes the following features:
- Integration with the Redux store to manage campaign state.
- Both table and card views for displaying campaign data.
- Pagination for both desktop and mobile views.
- Debounced search functionality.
- An action dropdown with an "Update" option.

The implementation is consistent with the existing architecture of the "brands" page.