### PR TITLE
feat: Add Redux functions for campaign APIs

### DIFF
--- a/src/store/campaign/campaignSlice.ts
+++ b/src/store/campaign/campaignSlice.ts
@@ -53,6 +53,54 @@ const campaignSlice = createSlice({
       state.loading = false;
       state.error = action.payload;
     },
+
+    // Fetch Campaign By ID
+    fetchCampaignByIdRequest: (state, action: PayloadAction<{ id: number }>) => {
+      state.loading = true;
+      state.error = null;
+    },
+    fetchCampaignByIdSuccess: (state, action: PayloadAction<Campaign>) => {
+      state.loading = false;
+      state.campaign = action.payload;
+    },
+    fetchCampaignByIdFailure: (state, action: PayloadAction<string>) => {
+      state.loading = false;
+      state.error = action.payload;
+    },
+
+    // Update Campaign Status
+    updateCampaignStatusRequest: (state, action: PayloadAction<{ id: number; status: 'Approved' | 'Rejected' }>) => {
+      state.loading = true;
+      state.error = null;
+    },
+    updateCampaignStatusSuccess: (state, action: PayloadAction<{ id: number; status: 'Approved' | 'Rejected' }>) => {
+      state.loading = false;
+      const { id, status } = action.payload;
+      const campaignIndex = state.campaigns.findIndex(c => c.id === id);
+      if (campaignIndex !== -1) {
+        state.campaigns[campaignIndex].status = status;
+      }
+      if (state.campaign && state.campaign.id === id) {
+        state.campaign.status = status;
+      }
+    },
+    updateCampaignStatusFailure: (state, action: PayloadAction<string>) => {
+      state.loading = false;
+      state.error = action.payload;
+    },
+
+    // Update Dedicated Status
+    updateDedicatedStatusRequest: (state, action: PayloadAction<{ id: number; status: 0 | 1; rejectReason?: string }>) => {
+      state.loading = true;
+      state.error = null;
+    },
+    updateDedicatedStatusSuccess: (state) => {
+      state.loading = false;
+    },
+    updateDedicatedStatusFailure: (state, action: PayloadAction<string>) => {
+      state.loading = false;
+      state.error = action.payload;
+    },
   },
 });
 
@@ -63,6 +111,15 @@ export const {
   fetchMoreCampaignsRequest,
   fetchMoreCampaignsSuccess,
   fetchMoreCampaignsFailure,
+  fetchCampaignByIdRequest,
+  fetchCampaignByIdSuccess,
+  fetchCampaignByIdFailure,
+  updateCampaignStatusRequest,
+  updateCampaignStatusSuccess,
+  updateCampaignStatusFailure,
+  updateDedicatedStatusRequest,
+  updateDedicatedStatusSuccess,
+  updateDedicatedStatusFailure,
 } = campaignSlice.actions;
 
 export default campaignSlice.reducer;


### PR DESCRIPTION
This commit adds new Redux actions, reducers, and sagas to handle various campaign-related API endpoints.

The new functionality includes:
- Fetching a single campaign by its ID (`GET /api/campaign/{id}`).
- Updating the status of a campaign (`POST /campaign/{id}/status`).
- Updating the status of a dedicated page (`POST /api/dedicated/{id}/status`).

The changes are implemented in `src/store/campaign/campaignSlice.ts` and `src/store/campaign/campaignSaga.ts`, following the existing Redux Toolkit and Redux Saga patterns in the codebase.