### PR TITLE
feat: Add Redux module for campaigns

### DIFF
--- a/src/store/campaigns/saga.ts
+++ b/src/store/campaigns/saga.ts
@@ -1,0 +1,74 @@
+import { call, put, takeLatest, all } from 'redux-saga/effects';
+import axiosInstance from '../../services/apiHelper';
+import {
+  getCampaignsStart,
+  getCampaignsSuccess,
+  getCampaignsFailure,
+  updateCampaignStatusStart,
+  updateCampaignStatusSuccess,
+  updateCampaignStatusFailure,
+  getCampaignDetailsStart,
+  getCampaignDetailsSuccess,
+  getCampaignDetailsFailure,
+  updateDedicatedPageStatusStart,
+  updateDedicatedPageStatusSuccess,
+  updateDedicatedPageStatusFailure,
+} from './slice';
+import {
+  GetCampaignsAction,
+  UpdateCampaignStatusAction,
+  GetCampaignDetailsAction,
+  UpdateDedicatedPageStatusAction,
+} from './types';
+
+function* getCampaignsSaga(action: GetCampaignsAction) {
+  try {
+    const response = yield call(axiosInstance.post, '/api/campaigns', action.payload);
+    yield put(getCampaignsSuccess(response.data));
+  } catch (error: any) {
+    yield put(getCampaignsFailure(error.message));
+  }
+}
+
+function* updateCampaignStatusSaga(action: UpdateCampaignStatusAction) {
+  try {
+    const { id, status } = action.payload;
+    yield call(axiosInstance.post, `/api/campaign/${id}/status`, { status });
+    yield put(updateCampaignStatusSuccess());
+  } catch (error: any) {
+    yield put(updateCampaignStatusFailure(error.message));
+  }
+}
+
+function* getCampaignDetailsSaga(action: GetCampaignDetailsAction) {
+  try {
+    const { id } = action.payload;
+    const response = yield call(axiosInstance.get, `/api/campaign/${id}`);
+    yield put(getCampaignDetailsSuccess(response.data));
+  } catch (error: any) {
+    yield put(getCampaignDetailsFailure(error.message));
+  }
+}
+
+function* updateDedicatedPageStatusSaga(action: UpdateDedicatedPageStatusAction) {
+  try {
+    const { id, ...payload } = action.payload;
+    yield call(axiosInstance.post, `/api/dedicated/${id}/status`, payload);
+    yield put(updateDedicatedPageStatusSuccess());
+  } catch (error: any) {
+    yield put(updateDedicatedPageStatusFailure(error.message));
+  }
+}
+
+function* watchCampaigns() {
+  yield takeLatest(getCampaignsStart.type, getCampaignsSaga);
+  yield takeLatest(updateCampaignStatusStart.type, updateCampaignStatusSaga);
+  yield takeLatest(getCampaignDetailsStart.type, getCampaignDetailsSaga);
+  yield takeLatest(updateDedicatedPageStatusStart.type, updateDedicatedPageStatusSaga);
+}
+
+export default function* campaignsSaga() {
+  yield all([
+    watchCampaigns(),
+  ]);
+}

--- a/src/store/campaigns/slice.ts
+++ b/src/store/campaigns/slice.ts
@@ -1,0 +1,79 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { CampaignsState } from './types';
+
+const initialState: CampaignsState = {
+  campaigns: [],
+  campaign: null,
+  loading: false,
+  error: null,
+};
+
+const campaignsSlice = createSlice({
+  name: 'campaigns',
+  initialState,
+  reducers: {
+    getCampaignsStart: (state) => {
+      state.loading = true;
+      state.error = null;
+    },
+    getCampaignsSuccess: (state, action) => {
+      state.loading = false;
+      state.campaigns = action.payload;
+    },
+    getCampaignsFailure: (state, action) => {
+      state.loading = false;
+      state.error = action.payload;
+    },
+    updateCampaignStatusStart: (state) => {
+      state.loading = true;
+      state.error = null;
+    },
+    updateCampaignStatusSuccess: (state) => {
+      state.loading = false;
+    },
+    updateCampaignStatusFailure: (state, action) => {
+      state.loading = false;
+      state.error = action.payload;
+    },
+    getCampaignDetailsStart: (state) => {
+      state.loading = true;
+      state.error = null;
+    },
+    getCampaignDetailsSuccess: (state, action) => {
+      state.loading = false;
+      state.campaign = action.payload;
+    },
+    getCampaignDetailsFailure: (state, action) => {
+      state.loading = false;
+      state.error = action.payload;
+    },
+    updateDedicatedPageStatusStart: (state) => {
+      state.loading = true;
+      state.error = null;
+    },
+    updateDedicatedPageStatusSuccess: (state) => {
+      state.loading = false;
+    },
+    updateDedicatedPageStatusFailure: (state, action) => {
+      state.loading = false;
+      state.error = action.payload;
+    },
+  },
+});
+
+export const {
+  getCampaignsStart,
+  getCampaignsSuccess,
+  getCampaignsFailure,
+  updateCampaignStatusStart,
+  updateCampaignStatusSuccess,
+  updateCampaignStatusFailure,
+  getCampaignDetailsStart,
+  getCampaignDetailsSuccess,
+  getCampaignDetailsFailure,
+  updateDedicatedPageStatusStart,
+  updateDedicatedPageStatusSuccess,
+  updateDedicatedPageStatusFailure,
+} = campaignsSlice.actions;
+
+export default campaignsSlice.reducer;

--- a/src/store/campaigns/types.ts
+++ b/src/store/campaigns/types.ts
@@ -1,0 +1,51 @@
+export interface Campaign {
+  id: string;
+  name: string;
+  status: string;
+}
+
+export interface GetCampaignsPayload {
+  search: string;
+}
+
+export interface GetCampaignsAction {
+  type: string;
+  payload: GetCampaignsPayload;
+}
+
+export interface UpdateCampaignStatusPayload {
+  id: string;
+  status: 'Approved' | 'Rejected';
+}
+
+export interface UpdateCampaignStatusAction {
+  type: string;
+  payload: UpdateCampaignStatusPayload;
+}
+
+export interface GetCampaignDetailsPayload {
+  id: string;
+}
+
+export interface GetCampaignDetailsAction {
+  type: string;
+  payload: GetCampaignDetailsPayload;
+}
+
+export interface UpdateDedicatedPageStatusPayload {
+  id: string;
+  status: 0 | 1;
+  rejectReason?: string;
+}
+
+export interface UpdateDedicatedPageStatusAction {
+  type: string;
+  payload: UpdateDedicatedPageStatusPayload;
+}
+
+export interface CampaignsState {
+  campaigns: Campaign[];
+  campaign: Campaign | null;
+  loading: boolean;
+  error: string | null;
+}

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -4,6 +4,7 @@ import accountReducer from './account/accountSlice';
 import brandReducer from './brand/brandSlice';
 import searchReducer from './search/searchSlice';
 import commonReducer from './common/commonSlice';
+import campaignsReducer from './campaigns/slice';
 
 const rootReducer = combineReducers({
   auth: authReducer,
@@ -11,6 +12,7 @@ const rootReducer = combineReducers({
   brand: brandReducer,
   search: searchReducer,
   common: commonReducer,
+  campaigns: campaignsReducer,
 });
 
 export default rootReducer;

--- a/src/store/rootSaga.ts
+++ b/src/store/rootSaga.ts
@@ -3,6 +3,7 @@ import authSaga from './auth/authSaga';
 import accountSaga from './account/accountSaga';
 import brandSaga from './brand/brandSaga';
 import commonSaga from './common/commonSaga';
+import campaignsSaga from './campaigns/saga';
 
 export default function* rootSaga() {
   yield all([
@@ -10,5 +11,6 @@ export default function* rootSaga() {
     accountSaga(),
     brandSaga(),
     commonSaga(),
+    campaignsSaga(),
   ]);
 }


### PR DESCRIPTION
This commit introduces a new Redux module to manage campaigns.

The new module includes:
- A 'campaigns' slice with actions and reducers to handle state updates for campaign data.
- Sagas to manage asynchronous API calls for fetching and updating campaign information.
- Type definitions for campaigns, API payloads, and action payloads.

The root reducer and root saga have been updated to integrate the new campaigns module.