### PR TITLE
fix(campaigns): Ensure campaigns state is always an array

### DIFF
--- a/src/app/(features)/businesses/campaigns/page.tsx
+++ b/src/app/(features)/businesses/campaigns/page.tsx
@@ -115,7 +115,7 @@ export default function CampaignsPage() {
     }
   };
 
-  const displayCampaigns = (campaigns || []).map(adaptCampaignSummaryToDisplay);
+  const displayCampaigns = campaigns.map(adaptCampaignSummaryToDisplay);
 
   return (
     <div>

--- a/src/store/campaigns/CampaignSlice.ts
+++ b/src/store/campaigns/CampaignSlice.ts
@@ -19,7 +19,7 @@ const campaignsSlice = createSlice({
     },
     getCampaignsSuccess: (state, action) => {
       state.loading = false;
-      state.campaigns = action.payload.data;
+      state.campaigns = action.payload.data || [];
       state.pagination = {
         current_page: action.payload.current_page,
         last_page: action.payload.last_page,


### PR DESCRIPTION
This commit fixes a runtime error on the campaigns page that occurred when the `campaigns` variable from the Redux store was `undefined`. This happened when the API response for campaigns was null or undefined.

The fix modifies the `getCampaignsSuccess` reducer in `CampaignSlice.ts` to ensure that `state.campaigns` is always an array by setting it to `action.payload.data || []`. This prevents the `.map()` function from being called on an undefined value, resolving the crash while preserving all existing data binding and UI logic.