### PR TITLE
fix(campaigns): Correct data path and add safety checks

### DIFF
--- a/src/store/campaigns/CampaignSaga.ts
+++ b/src/store/campaigns/CampaignSaga.ts
@@ -26,7 +26,7 @@ import {
 function* getCampaignsSaga(action: GetCampaignsAction) {
   try {
     const response = yield call(axiosInstance.post, '/api/campaigns', action.payload);
-    yield put(getCampaignsSuccess(response.data));
+    yield put(getCampaignsSuccess(response.data.venues));
   } catch (error: any) {
     yield put(getCampaignsFailure(error.message));
   }
@@ -35,7 +35,7 @@ function* getCampaignsSaga(action: GetCampaignsAction) {
 function* getMoreCampaignsSaga(action: GetCampaignsAction) {
   try {
     const response = yield call(axiosInstance.post, '/api/campaigns', action.payload);
-    yield put(getMoreCampaignsSuccess(response.data));
+    yield put(getMoreCampaignsSuccess(response.data.venues));
   } catch (error: any) {
     yield put(getCampaignsFailure(error.message));
   }

--- a/src/store/campaigns/CampaignSlice.ts
+++ b/src/store/campaigns/CampaignSlice.ts
@@ -36,7 +36,7 @@ const campaignsSlice = createSlice({
     },
     getMoreCampaignsSuccess: (state, action) => {
       state.loading = false;
-      state.campaigns = [...state.campaigns, ...action.payload.data];
+      state.campaigns = [...state.campaigns, ...(action.payload.data || [])];
       state.pagination = {
         current_page: action.payload.current_page,
         last_page: action.payload.last_page,


### PR DESCRIPTION
This commit resolves a critical issue where campaign data was not being displayed in the UI. The root cause was a mismatch between the frontend's expected data structure and the actual API response.

The campaign list data from the API is nested under a `venues` key, which the saga was not accounting for. This commit corrects the data path in `CampaignSaga.ts` to access `response.data.venues`, ensuring the correct data is passed to the Redux store.

Additionally, safety checks have been added to the `getMoreCampaignsSuccess` reducer in `CampaignSlice.ts` to handle cases where the API might return an empty payload, preventing potential future errors during pagination.