### PR TITLE
fix(campaigns): Resolve details page error and update page size

### DIFF
--- a/src/app/(features)/businesses/campaigns/page.tsx
+++ b/src/app/(features)/businesses/campaigns/page.tsx
@@ -38,7 +38,7 @@ export default function CampaignsPage() {
   const debouncedSearch = useDebounce(searchTerm, 500);
 
   useEffect(() => {
-    dispatch(getCampaignsStart({ page: 1, per_page: 10 }));
+    dispatch(getCampaignsStart({ page: 1, per_page: 12 }));
   }, [dispatch]);
 
   const isInitialSearchMount = useRef(true);
@@ -52,7 +52,7 @@ export default function CampaignsPage() {
     dispatch(
       getCampaignsStart({
         search: debouncedSearch,
-        per_page: 10,
+        per_page: 12,
         page: 1,
       })
     );
@@ -86,7 +86,7 @@ export default function CampaignsPage() {
       getMoreCampaignsStart({
         page: nextPage,
         search: debouncedSearch,
-        per_page: 10,
+        per_page: 12,
       })
     );
     setMobilePage(nextPage);

--- a/src/components/features/campaigns/tabs/Overview/CampaignPlans.tsx
+++ b/src/components/features/campaigns/tabs/Overview/CampaignPlans.tsx
@@ -6,6 +6,10 @@ interface CampaignPlansProps {
 }
 
 export default function CampaignPlans({ campaign }: CampaignPlansProps) {
+  if (!campaign?.campaignPlan) {
+    return null;
+  }
+
   return (
     <div>
       <div className=" mt-5 mb-4">


### PR DESCRIPTION
This commit includes two main fixes:

1.  **Fix Runtime Error on Campaign Details Page:** A runtime error (`Cannot read properties of undefined (reading 'planName')`) was occurring in the `CampaignPlans` component. This was caused by the component attempting to access `campaign.campaignPlan` when the `campaign` object from the API did not include a `campaignPlan` property. The fix adds a guard clause to the `CampaignPlans` component to check for the existence of `campaign.campaignPlan` before attempting to render, preventing the application from crashing.

2.  **Update Default Page Size for Campaign List:** The default number of items fetched per page for the campaign list has been updated from 10 to 12. This change has been applied to the initial data fetch, the search functionality, and the 'See More' pagination in `src/app/(features)/businesses/campaigns/page.tsx`.