### PR TITLE
fix(campaigns): Correct API endpoint and rejection payload

### DIFF
--- a/src/components/features/campaigns/CampaignDetails.tsx
+++ b/src/components/features/campaigns/CampaignDetails.tsx
@@ -57,7 +57,7 @@ export default function CampaignDetails({ campaign, campaignId }: { campaign: Ca
       updateCampaignStatusStart({
         id: campaignId,
         status: "Rejected",
-        reason,
+        rejectReason: reason,
       })
     );
     setRejectionModalOpen(false);

--- a/src/components/general/modals/RejectionModal.tsx
+++ b/src/components/general/modals/RejectionModal.tsx
@@ -34,7 +34,7 @@ export default function RejectionModal({
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-black bg-opacity-25" />
+          <div className="fixed inset-0" />
         </Transition.Child>
 
         <div className="fixed inset-0 overflow-y-auto">

--- a/src/store/campaigns/CampaignSaga.ts
+++ b/src/store/campaigns/CampaignSaga.ts
@@ -44,7 +44,7 @@ function* getMoreCampaignsSaga(action: GetCampaignsAction) {
 function* updateCampaignStatusSaga(action: UpdateCampaignStatusAction) {
   try {
     const { id, ...payload } = action.payload;
-    yield call(axiosInstance.post, `/campaign/${id}/status`, payload);
+    yield call(axiosInstance.post, `/api/campaign/${id}/status`, payload);
     yield put(updateCampaignStatusSuccess());
   } catch (error: any) {
     yield put(updateCampaignStatusFailure(error.message));


### PR DESCRIPTION
This commit addresses several corrections to the campaign approval and rejection workflow based on user feedback.

Key changes include:
- **Corrected API Endpoint:** The `updateCampaignStatusSaga` now correctly calls the `/api/campaign/{id}/status` endpoint, instead of the incorrect `/campaign/{id}/status` path.
- **Corrected Rejection Payload:** The `handleRejectSubmit` function in `CampaignDetails.tsx` now dispatches the rejection reason using the correct `rejectReason` key in the payload, as required by the API.
- **Transparent Modal Backdrop:** The styling for the `RejectionModal` has been updated to make the backdrop overlay transparent, as requested.