### PR TITLE
feat(campaigns): Implement creator approval flow for dedicated offers

### DIFF
--- a/src/components/features/campaigns/tabs/Creators.tsx
+++ b/src/components/features/campaigns/tabs/Creators.tsx
@@ -1,47 +1,90 @@
 "use client";
-import CampaignCreatorCard from "./Creators/CampaignCreatorCard";
+
 import { useState } from "react";
-import { CreatorsData } from "@/data/CreatorsData";
+import { useDispatch } from "react-redux";
 import { Campaign } from "@/types/entities";
+import { updateDedicatedPageStatusStart } from "@/store/campaigns/CampaignSlice";
+import CampaignCreatorCard from "./Creators/CampaignCreatorCard";
+import RejectionModal from "@/components/general/modals/RejectionModal";
+
+// Helper function to format follower count
+const formatFollowers = (count: number = 0) => {
+  if (count >= 1000000) {
+    return `${(count / 1000000).toFixed(1)}M`;
+  }
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(0)}K`;
+  }
+  return count.toString();
+};
 
 export default function Creators({ campaign }: { campaign: Campaign }) {
-  // Fetch creators that have this campaign ID in their campaignIds array
-  const campaignCreators = CreatorsData.filter((creator) =>
-    creator.campaignIds.includes(campaign.campaignId)
-  );
+  const dispatch = useDispatch();
+  const [isRejectionModalOpen, setRejectionModalOpen] = useState(false);
+  const [selectedCreatorId, setSelectedCreatorId] = useState<string | null>(null);
 
-  // Map creator data to match CampaignCreatorCard props
-  const mappedCreators = campaignCreators.map((creator) => ({
-    id: creator.creatorId,
-    image: creator.avatarUrl,
-    name: creator.fullName,
-    instagramName:
-      creator.socialHandles.find((handle) => handle.platform === "Instagram")
-        ?.handle || creator.fullName.toLowerCase().replace(/\s+/g, "."),
-    stats: {
-      followers:
-        creator.followerCount >= 1000
-          ? `${(creator.followerCount / 1000).toFixed(0)}K`
-          : creator.followerCount.toString(),
-      credibility: `${creator.credibilityScore}%`,
-      engagement: `${creator.engagementRate.toFixed(2)}%`,
-    },
-    approved: creator.isApproved,
-  }));
-
-  const [creators, setCreators] = useState(mappedCreators);
-
-  const handleDelete = (id: string) => {
-    setCreators((prevCreators) =>
-      prevCreators.filter((creator) => creator.id !== id)
-    );
+  const handleApprove = (offerUserId: string) => {
+    dispatch(updateDedicatedPageStatusStart({ id: offerUserId, status: 1 }));
   };
+
+  const handleReject = (offerUserId: string) => {
+    setSelectedCreatorId(offerUserId);
+    setRejectionModalOpen(true);
+  };
+
+  const handleRejectSubmit = (reason: string) => {
+    if (selectedCreatorId) {
+      dispatch(
+        updateDedicatedPageStatusStart({
+          id: selectedCreatorId,
+          status: 0,
+          rejectReason: reason,
+        })
+      );
+    }
+    setRejectionModalOpen(false);
+    setSelectedCreatorId(null);
+  };
+
+  const isDedicated = campaign?.is_dedicated === 1;
+  const offerUsers = campaign?.dedicated_offer?.offer_users || [];
+
+  if (!isDedicated) {
+    return (
+      <div className="text-center py-10 text-gray-500">
+        This is not a dedicated offer. Creator approval is not required.
+      </div>
+    );
+  }
+
+  if (offerUsers.length === 0) {
+    return (
+      <div className="text-center py-10 text-gray-500">
+        No creators have been assigned to this dedicated offer yet.
+      </div>
+    );
+  }
+
+  const mappedCreators = offerUsers.map((offerUser) => ({
+    id: offerUser.user.id.toString(), // Using the main user ID for the key
+    offerUserId: offerUser.id, // This is the ID for the status update API
+    image: offerUser.user.avatar || "/default-avatar.png",
+    name: offerUser.user.name || "Unknown Creator",
+    instagramName: offerUser.user.instagram_handle || "N/A",
+    stats: {
+      followers: formatFollowers(offerUser.user.followers_count),
+      credibility: `${offerUser.user.credibility_score || 0}%`,
+      engagement: `${(offerUser.user.engagement_rate || 0).toFixed(2)}%`,
+    },
+    // Assuming status is a string like "Approved", "Rejected", "Pending"
+    status: offerUser.status,
+  }));
 
   return (
     <div>
       <div className="max-w-[966px] mx-auto">
-        <h3 className="md:text-[18px] text-[15px] md:leading-[27px] leading-[23px]  text-[#4F4F4F] font-medium md:mt-10 mt-[25.5px] md:mb-8.5 mb-[9.5px] text-center">
-          A minimum of 3 creators must be approved
+        <h3 className="md:text-[18px] text-[15px] md:leading-[27px] leading-[23px] text-[#4F4F4F] font-medium md:mt-10 mt-[25.5px] md:mb-8.5 mb-[9.5px] text-center">
+          Approve or reject the following creators for this dedicated offer.
         </h3>
         <div className="grid gap-3 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 justify-items-center justify-center">
           <style jsx>{`
@@ -51,15 +94,26 @@ export default function Creators({ campaign }: { campaign: Campaign }) {
               }
             }
           `}</style>
-          {creators.map((creator) => (
+          {mappedCreators.map((creator) => (
             <CampaignCreatorCard
               key={creator.id}
-              {...creator}
-              onDelete={handleDelete}
+              id={creator.offerUserId.toString()}
+              image={creator.image}
+              name={creator.name}
+              instagramName={creator.instagramName}
+              stats={creator.stats}
+              status={creator.status}
+              onApprove={handleApprove}
+              onReject={handleReject}
             />
           ))}
         </div>
       </div>
+      <RejectionModal
+        isOpen={isRejectionModalOpen}
+        onClose={() => setRejectionModalOpen(false)}
+        onSubmit={handleRejectSubmit}
+      />
     </div>
   );
 }

--- a/src/components/features/campaigns/tabs/Creators/CampaignCreatorCard.tsx
+++ b/src/components/features/campaigns/tabs/Creators/CampaignCreatorCard.tsx
@@ -1,8 +1,7 @@
 import Image from "next/image";
-import { useState } from "react";
 
 interface CampaignCreatorCardProps {
-  id: string;
+  id: string; // This will be the offerUserId
   image: string;
   name: string;
   instagramName: string;
@@ -11,8 +10,9 @@ interface CampaignCreatorCardProps {
     credibility: string;
     engagement: string;
   };
-  approved?: boolean;
-  onDelete?: (id: string) => void;
+  status: string; // 'Approved', 'Rejected', 'Pending'
+  onApprove: (id: string) => void;
+  onReject: (id: string) => void;
 }
 
 export default function CampaignCreatorCard({
@@ -21,18 +21,55 @@ export default function CampaignCreatorCard({
   name,
   instagramName,
   stats,
-  approved = false,
-  onDelete,
+  status,
+  onApprove,
+  onReject,
 }: CampaignCreatorCardProps) {
-  const [isApproved, setIsApproved] = useState(approved);
-
   const handleApprove = () => {
-    setIsApproved(true);
+    onApprove(id);
   };
 
   const handleReject = () => {
-    if (onDelete) {
-      onDelete(id);
+    onReject(id);
+  };
+
+  const renderStatus = () => {
+    switch (status) {
+      case "Approved":
+        return (
+          <div className="flex-1 flex items-center md:justify-center gap-2 text-[#00A4B6] py-[7px] md:rounded-[13px] rounded-[11px] text-[13px] leading-[20px] font-medium h-[38px]">
+            <Image
+              src="/icons/campaign/details/creators-and-posts/verified-check.svg"
+              alt="Approved"
+              width={10.62}
+              height={9.09}
+            />
+            <p>Approved</p>
+          </div>
+        );
+      case "Rejected":
+        return (
+          <div className="flex-1 flex items-center md:justify-center gap-2 text-red-500 py-[7px] md:rounded-[13px] rounded-[11px] text-[13px] leading-[20px] font-medium h-[38px]">
+            <p>Rejected</p>
+          </div>
+        );
+      default: // "Pending" or other statuses
+        return (
+          <>
+            <button
+              onClick={handleApprove}
+              className="flex-1 bg-[#00A4B6] text-white py-[7px] md:rounded-[13px] rounded-[11px] md:text-[16px] text-[15px] leading-[23px] h-[38px]"
+            >
+              Approve
+            </button>
+            <button
+              onClick={handleReject}
+              className="flex-1 bg-[#747474] text-white py-[7px] md:rounded-[13px] rounded-[11px] md:text-[16px] text-[15px] leading-[23px] h-[38px]"
+            >
+              Reject
+            </button>
+          </>
+        );
     }
   };
 
@@ -97,32 +134,7 @@ export default function CampaignCreatorCard({
 
         {/* Action buttons or Approved text */}
         <div className="flex md:gap-[9px] gap-2 md:pb-[9px] md:pl-[9px] md:pr-[9px] pr-3">
-          {isApproved ? (
-            <div className="flex-1 flex items-center md:justify-center gap-2  text-[#00A4B6] py-[7px] md:rounded-[13px] rounded-[11px]  text-[13px] leading-[20px] font-medium h-[38px]">
-              <Image
-                src="/icons/campaign/details/creators-and-posts/verified-check.svg"
-                alt="Approved"
-                width={10.62}
-                height={9.09}
-              />
-              <p>Approved</p>
-            </div>
-          ) : (
-            <>
-              <button
-                onClick={handleApprove}
-                className="flex-1 bg-[#00A4B6] text-white py-[7px] md:rounded-[13px] rounded-[11px] md:text-[16px] text-[15px] leading-[23px] h-[38px]"
-              >
-                Approve
-              </button>
-              <button
-                onClick={handleReject}
-                className="flex-1 bg-[#747474] text-white py-[7px] md:rounded-[13px] rounded-[11px] md:text-[16px] text-[15px] leading-[23px] h-[38px]"
-              >
-                Reject
-              </button>
-            </>
-          )}
+          {renderStatus()}
         </div>
       </div>
     </article>

--- a/src/components/features/campaigns/tabs/Overview.tsx
+++ b/src/components/features/campaigns/tabs/Overview.tsx
@@ -1,17 +1,12 @@
 "use client";
 
 import Image from "next/image";
-import { useDispatch } from "react-redux";
 import { Campaign } from "@/types/entities";
 import CampaignStats from "./Overview/CampaignStats";
 import CampaignCreators from "./Overview/CampaignCreators";
 import CampaignDetails from "./Overview/CampaignDetails";
 import CampaignGuidlines from "./Overview/CampaignGuidlines";
 import CampaignPlans from "./Overview/CampaignPlans";
-import {
-  updateCampaignStatusStart,
-  updateDedicatedPageStatusStart,
-} from "@/store/campaigns/CampaignSlice";
 
 export default function Overview({
   campaign,
@@ -20,35 +15,6 @@ export default function Overview({
   campaign: Campaign;
   campaignId: string;
 }) {
-  const dispatch = useDispatch();
-
-  const handleApprove = () => {
-    dispatch(updateCampaignStatusStart({ id: campaignId, status: "Approved" }));
-  };
-
-  const handleReject = () => {
-    dispatch(updateCampaignStatusStart({ id: campaignId, status: "Rejected" }));
-  };
-
-  const handleApproveDedicatedPage = () => {
-    // Assuming the dedicated page ID is the same as the campaign ID for now.
-    // This might need to be adjusted if the API provides a separate dedicated page ID.
-    dispatch(updateDedicatedPageStatusStart({ id: campaignId, status: 1 }));
-  };
-
-  const handleRejectDedicatedPage = () => {
-    const rejectReason = prompt("Please provide a reason for rejection:");
-    if (rejectReason) {
-      dispatch(
-        updateDedicatedPageStatusStart({
-          id: campaignId,
-          status: 0,
-          rejectReason,
-        })
-      );
-    }
-  };
-
   return (
     <div className="max-w-[774px] mx-auto mt-[13px] pb-[100px]">
       <div className="flex bg-[#F8F8F8] rounded-[13px] overflow-hidden">
@@ -106,24 +72,6 @@ export default function Overview({
         <CampaignGuidlines campaign={campaign} />
       </div>
       <CampaignPlans campaign={campaign} />
-
-      <div className="mt-8">
-        <h3 className="text-lg font-semibold mb-2">Dedicated Page Actions</h3>
-        <div className="flex space-x-4">
-          <button
-            onClick={handleApproveDedicatedPage}
-            className="bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600"
-          >
-            Approve Dedicated Page
-          </button>
-          <button
-            onClick={handleRejectDedicatedPage}
-            className="bg-orange-500 text-white px-4 py-2 rounded-lg hover:bg-orange-600"
-          >
-            Reject Dedicated Page
-          </button>
-        </div>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
This commit introduces a complete approval and rejection workflow for creators within dedicated offers, and addresses several other UI and API integration issues.

Key Features and Fixes:
- **Creator Approval Flow:** The 'Creators' tab now correctly displays creators assigned to a dedicated offer (from `campaign.dedicated_offer.offer_users`). Each creator card has 'Approve' and 'Reject' buttons that are wired up to the `/api/dedicated/{id}/status` endpoint.
- **Refactored Components:** The `Creators` tab and `CampaignCreatorCard` have been completely refactored to be driven by API data instead of static data. The card now displays the correct status ('Approved', 'Rejected', 'Pending') for each creator.
- **Rejection Modal:** The rejection flow for creators reuses the existing modal to capture a rejection reason, which is correctly passed to the API.
- **UI Cleanup:** The old, redundant 'Dedicated Page Actions' section has been removed from the 'Overview' tab, as it is now replaced by the per-creator approval functionality.