### PR TITLE
fix(campaigns): Prevent crash on details page when campaignPlan is mi…

### DIFF
--- a/src/components/features/campaigns/tabs/Overview/CampaignPlans.tsx
+++ b/src/components/features/campaigns/tabs/Overview/CampaignPlans.tsx
@@ -6,6 +6,10 @@ interface CampaignPlansProps {
 }
 
 export default function CampaignPlans({ campaign }: CampaignPlansProps) {
+  if (!campaign?.campaignPlan) {
+    return null;
+  }
+
   return (
     <div>
       <div className=" mt-5 mb-4">


### PR DESCRIPTION
…ssing

This commit fixes a runtime error (`Cannot read properties of undefined (reading 'planName')`) that occurred on the campaign details page.

The error was caused by the `CampaignPlans` component attempting to access properties of `campaign.campaignPlan` when the `campaignPlan` object was not present in the campaign data fetched from the API.

The fix adds a guard clause to the `CampaignPlans` component. It now checks for the existence of `campaign.campaignPlan` before attempting to render the component, returning `null` if the data is missing. This prevents the application from crashing and ensures the page remains stable.