### PR TITLE
fix: Correctly handle payload in getCampaignDetailsStart action

### DIFF
--- a/src/store/campaigns/CampaignSlice.ts
+++ b/src/store/campaigns/CampaignSlice.ts
@@ -55,7 +55,7 @@ const campaignsSlice = createSlice({
       state.loading = false;
       state.error = action.payload;
     },
-    getCampaignDetailsStart: (state) => {
+    getCampaignDetailsStart: (state, action) => {
       state.loading = true;
       state.error = null;
     },


### PR DESCRIPTION
The getCampaignDetailsStart action creator was being dispatched with a payload, but the corresponding reducer in CampaignSlice.ts was not defined to accept one. This caused a TypeScript type error during the build process.

This commit updates the getCampaignDetailsStart reducer to accept an action with a payload, resolving the type mismatch and allowing the campaign ID to be passed to the saga.