### PR TITLE
fix(redux): Correct payload types for campaign actions

### DIFF
--- a/src/store/campaigns/CampaignSlice.ts
+++ b/src/store/campaigns/CampaignSlice.ts
@@ -1,5 +1,9 @@
-import { createSlice } from '@reduxjs/toolkit';
-import { CampaignsState } from '../../types/entities/campaign';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import {
+  CampaignsState,
+  GetCampaignDetailsPayload,
+  UpdateCampaignStatusPayload,
+} from '../../types/entities/campaign';
 
 const initialState: CampaignsState = {
   campaigns: [],
@@ -44,7 +48,10 @@ const campaignsSlice = createSlice({
         total: action.payload.total,
       };
     },
-    updateCampaignStatusStart: (state) => {
+    updateCampaignStatusStart: (
+      state,
+      action: PayloadAction<UpdateCampaignStatusPayload>
+    ) => {
       state.loading = true;
       state.error = null;
     },
@@ -55,7 +62,10 @@ const campaignsSlice = createSlice({
       state.loading = false;
       state.error = action.payload;
     },
-    getCampaignDetailsStart: (state, action) => {
+    getCampaignDetailsStart: (
+      state,
+      action: PayloadAction<GetCampaignDetailsPayload>
+    ) => {
       state.loading = true;
       state.error = null;
     },


### PR DESCRIPTION
The `getCampaignDetailsStart` and `updateCampaignStatusStart` action creators were being dispatched with payloads, but their corresponding reducers in `CampaignSlice.ts` were not defined to accept them. This caused TypeScript type errors during the build process.

This commit updates the reducers to use `PayloadAction` with the correct payload types. This resolves the type mismatches and ensures the actions are correctly typed according to Redux Toolkit best practices, while allowing the sagas to consume the payloads as intended.