### PR TITLE
Fixes and features for campaign and brand pages (Round 2)

### DIFF
--- a/src/app/(features)/businesses/campaigns/page.tsx
+++ b/src/app/(features)/businesses/campaigns/page.tsx
@@ -105,7 +105,10 @@ export default function CampaignsPage() {
   };
 
   const handleActionSelect = (value: string) => {
-    if (value === "Approved" || value === "Rejected") {
+    if (value === "update") {
+      const selectedId = checkedRows.values().next().value;
+      router.push(`/businesses/campaigns/${selectedId}/edit`);
+    } else if (value === "Approved" || value === "Rejected") {
       checkedRows.forEach((id) => {
         dispatch(updateCampaignStatusStart({ id, status: value }));
       });
@@ -140,6 +143,7 @@ export default function CampaignsPage() {
               <ActionDropdown
                 onSelect={handleActionSelect}
                 disabled={checkedRows.size === 0}
+                showUpdate={checkedRows.size === 1}
                 excludeActions={["delete", "active", "inactive"]}
               />
             </div>

--- a/src/components/features/accounts/AccountHeader.tsx
+++ b/src/components/features/accounts/AccountHeader.tsx
@@ -65,9 +65,6 @@ export default function AccountHeader({
             onTabChange={onTabChange}
           />
         </div>
-        <div>
-          <Image src={menuIcon} alt="MENU" width={21.48} height={4.67} />
-        </div>
       </div>
     </div>
   );

--- a/src/components/features/campaigns/tabs/Creators.tsx
+++ b/src/components/features/campaigns/tabs/Creators.tsx
@@ -13,18 +13,20 @@ export default function Creators({ campaign }: { campaign: Campaign }) {
   );
 
   const mappedCreators = useMemo(() => {
-    return creators.map((offerUser) => ({
-      id: offerUser.user.id.toString(),
-      image: offerUser.user.profile_photo || "/images/creators/profile.png",
-      name: offerUser.user.name,
-      instagramName: offerUser.user.instagram_handle || "N/A",
-      stats: {
-        followers: "0", // Placeholder
-        credibility: "0%", // Placeholder
-        engagement: "0%", // Placeholder
-      },
-      approved: offerUser.status === 1, // Assuming 1 is approved
-    }));
+    return creators
+      .filter((offerUser) => offerUser.user)
+      .map((offerUser) => ({
+        id: offerUser.user.id.toString(),
+        image: offerUser.user.profile_photo || "/images/creators/profile.png",
+        name: offerUser.user.name,
+        instagramName: offerUser.user.instagram_handle || "N/A",
+        stats: {
+          followers: "0", // Placeholder
+          credibility: "0%", // Placeholder
+          engagement: "0%", // Placeholder
+        },
+        approved: offerUser.status === 1, // Assuming 1 is approved
+      }));
   }, [creators]);
 
   const paginatedCreators = useMemo(() => {
@@ -34,7 +36,12 @@ export default function Creators({ campaign }: { campaign: Campaign }) {
 
   const handleDelete = (id: string) => {
     setCreators((prevCreators) =>
-      prevCreators.filter((creator) => creator.user.id.toString() !== id)
+      prevCreators.filter((creator) => {
+        if (!creator.user) {
+          return true; // Keep creators that don't have a user object
+        }
+        return creator.user.id.toString() !== id;
+      })
     );
   };
 

--- a/src/components/general/dropdowns/ActionDropdown.tsx
+++ b/src/components/general/dropdowns/ActionDropdown.tsx
@@ -7,6 +7,7 @@ interface ActionDropdownProps {
   showUpdate?: boolean;
   disabled?: boolean;
   excludeActions?: string[];
+  actions?: string[];
 }
 
 export default function ActionDropdown({
@@ -14,20 +15,9 @@ export default function ActionDropdown({
   showUpdate,
   disabled,
   excludeActions = [],
+  actions,
 }: ActionDropdownProps) {
-  const allOptions = [
-    ...(showUpdate
-      ? [
-          {
-            value: "update",
-            label: (
-              <div className="flex items-center px-3 py-2 text-[#6E6E6E]">
-                <span>Update</span>
-              </div>
-            ),
-          },
-        ]
-      : []),
+  const baseOptions = [
     {
       value: "delete",
       label: (
@@ -52,11 +42,50 @@ export default function ActionDropdown({
         </div>
       ),
     },
+    {
+      value: "Approved",
+      label: (
+        <div className="flex items-center px-3 py-2 text-[#6E6E6E]">
+          <span>Approve</span>
+        </div>
+      ),
+    },
+    {
+      value: "Rejected",
+      label: (
+        <div className="flex items-center px-3 py-2 text-[#6E6E6E]">
+          <span>Reject</span>
+        </div>
+      ),
+    },
   ];
 
-  const options = allOptions.filter(
-    (option) => !excludeActions.includes(option.value)
-  );
+  const updateOption = {
+    value: "update",
+    label: (
+      <div className="flex items-center px-3 py-2 text-[#6E6E6E]">
+        <span>Update</span>
+      </div>
+    ),
+  };
+
+  let allOptions = [...baseOptions];
+  if (showUpdate) {
+    allOptions.unshift(updateOption);
+  }
+
+  let options;
+  if (actions) {
+    const allPossibleOptions = [updateOption, ...baseOptions];
+    const lowerCaseActions = actions.map((a) => a.toLowerCase());
+    options = allPossibleOptions.filter((opt) =>
+      lowerCaseActions.includes(opt.value.toLowerCase())
+    );
+  } else {
+    options = allOptions.filter(
+      (option) => !excludeActions.includes(option.value)
+    );
+  }
 
   const title = (
     <div className="text-[18px] px-6 text-white leading-[27px]">


### PR DESCRIPTION
This commit addresses several issues, including:
1.  Fixes a runtime error in the Creators tab by adding a null check for the user object.
2.  Removes the action dropdown from the account details page.
3.  Conditionally shows the 'Update' option in the campaign list dropdown, only when a single campaign is selected.
4.  Fixes the `handleDelete` function in `Creators.tsx` to prevent crashes.
5.  Makes the `ActionDropdown` component more flexible and reusable.