### PR TITLE
feat: Update campaign list UI and add delete confirmations

### DIFF
--- a/src/app/(features)/businesses/accounts/page.tsx
+++ b/src/app/(features)/businesses/accounts/page.tsx
@@ -2,9 +2,15 @@
 
 import { useEffect, useState, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import toast from "react-hot-toast";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useRouter } from "next/navigation";
-import { fetchAccountsRequest, bulkDeleteAccountsRequest, bulkUpdateStatusRequest, fetchMoreAccountsRequest } from "@/store/account/accountSlice";
+import {
+  fetchAccountsRequest,
+  bulkDeleteAccountsRequest,
+  bulkUpdateStatusRequest,
+  fetchMoreAccountsRequest,
+} from "@/store/account/accountSlice";
 import { setSearchTerm } from "@/store/search/searchSlice";
 import { RootState } from "@/store/store";
 import AccountsTable from "@/components/features/accounts/AccountsTable";
@@ -53,11 +59,13 @@ export default function AccountsPage() {
 
     setMobilePage(1); // Reset page number
     // Debounced search effect
-    dispatch(fetchAccountsRequest({
-      search: debouncedSearch,
-      per_page: 10,
-      page: 1
-    }));
+    dispatch(
+      fetchAccountsRequest({
+        search: debouncedSearch,
+        per_page: 10,
+        page: 1,
+      })
+    );
   }, [debouncedSearch, dispatch]);
 
   useEffect(() => {
@@ -73,15 +81,19 @@ export default function AccountsPage() {
   }, [bulkUpdateStatusInProgress, bulkUpdateStatusError]);
 
   const handlePageChange = (page: number) => {
-    dispatch(fetchAccountsRequest({
-      page,
-      search: searchTerm,
-      per_page: pagination.perPage
-    }));
+    dispatch(
+      fetchAccountsRequest({
+        page,
+        search: searchTerm,
+        per_page: pagination.perPage,
+      })
+    );
   };
 
   const handleItemsPerPageChange = (items: number) => {
-    dispatch(fetchAccountsRequest({ search: searchTerm, per_page: items, page: 1 }));
+    dispatch(
+      fetchAccountsRequest({ search: searchTerm, per_page: items, page: 1 })
+    );
   };
 
   // const handleSortSelect = (value: string) => {
@@ -103,12 +115,23 @@ export default function AccountsPage() {
     }
     if (value === "delete") {
       if (checkedRows.size > 0) {
-        dispatch(bulkDeleteAccountsRequest({ account_ids: Array.from(checkedRows) }));
+        const account_ids = Array.from(checkedRows);
+        const promise = dispatch(bulkDeleteAccountsRequest({ account_ids }));
+        toast.promise(promise, {
+          loading: "Deleting accounts...",
+          success: "Accounts deleted successfully!",
+          error: "Failed to delete accounts.",
+        });
       }
     }
     if (value === "active" || value === "inactive") {
       if (checkedRows.size > 0) {
-        dispatch(bulkUpdateStatusRequest({ account_ids: Array.from(checkedRows), status: value }));
+        dispatch(
+          bulkUpdateStatusRequest({
+            account_ids: Array.from(checkedRows),
+            status: value,
+          })
+        );
       }
     }
   };
@@ -127,11 +150,13 @@ export default function AccountsPage() {
 
   const handleSeeMore = () => {
     const nextPage = mobilePage + 1;
-    dispatch(fetchMoreAccountsRequest({
-      page: nextPage,
-      search: searchTerm,
-      per_page: 10
-    }));
+    dispatch(
+      fetchMoreAccountsRequest({
+        page: nextPage,
+        search: searchTerm,
+        per_page: 10,
+      })
+    );
     setMobilePage(nextPage);
   };
 
@@ -214,7 +239,9 @@ export default function AccountsPage() {
                       key={account.accountId}
                       account={account}
                       checked={checkedRows.has(account.accountId)}
-                      onCheckboxChange={() => handleCheckboxChange(account.accountId)}
+                      onCheckboxChange={() =>
+                        handleCheckboxChange(account.accountId)
+                      }
                     />
                   ))
                 )}
@@ -225,7 +252,7 @@ export default function AccountsPage() {
                       disabled={loading}
                       className="disabled:text-gray-400"
                     >
-                      {loading ? <InlineLoader /> : 'See More'}
+                      {loading ? <InlineLoader /> : "See More"}
                     </button>
                   </div>
                 )}

--- a/src/app/(features)/businesses/campaigns/page.tsx
+++ b/src/app/(features)/businesses/campaigns/page.tsx
@@ -8,6 +8,7 @@ import Pagination from "@/components/general/Pagination";
 import { adaptCampaignSummaryToDisplay } from "@/utils/campaignAdapters";
 import { useEffect, useState, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import toast from "react-hot-toast";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useRouter } from "next/navigation";
 import {
@@ -106,9 +107,16 @@ export default function CampaignsPage() {
 
   const handleActionSelect = (value: string) => {
     if (value === "delete") {
-      checkedRows.forEach((id) => {
-        dispatch(deleteCampaignStart({ id }));
+      const promises = Array.from(checkedRows).map((id) =>
+        dispatch(deleteCampaignStart({ id }))
+      );
+
+      toast.promise(Promise.all(promises), {
+        loading: "Deleting campaigns...",
+        success: "Campaigns deleted successfully",
+        error: "Error deleting campaigns",
       });
+
       setCheckedRows(new Set());
     }
   };
@@ -177,7 +185,7 @@ export default function CampaignsPage() {
                         disabled={loading}
                         className="disabled:text-gray-400"
                       >
-                        {loading ? <InlineLoader /> : 'See More'}
+                        {loading ? <InlineLoader /> : "See More"}
                       </button>
                     </div>
                   )}
@@ -185,11 +193,7 @@ export default function CampaignsPage() {
               <div className="hidden md:block">
                 {view === "table" ? (
                   <>
-                    <CampaignsTable
-                      campaigns={displayCampaigns}
-                      checkedRows={checkedRows}
-                      onCheckboxChange={handleCheckboxChange}
-                    />
+                    <CampaignsTable campaigns={displayCampaigns} />
                     {pagination && displayCampaigns.length > 0 && (
                       <Pagination
                         totalItems={pagination.total}
@@ -213,7 +217,13 @@ export default function CampaignsPage() {
                             key={campaign.id}
                             href={`/businesses/campaigns/${campaign.id}`}
                           >
-                            <CampaignCard campaign={campaign} />
+                            <CampaignCard
+                              campaign={campaign}
+                              checked={checkedRows.has(campaign.id.toString())}
+                              onCheckboxChange={() =>
+                                handleCheckboxChange(campaign.id.toString())
+                              }
+                            />
                           </Link>
                         ))
                       )}

--- a/src/components/features/campaigns/CampaignCard.tsx
+++ b/src/components/features/campaigns/CampaignCard.tsx
@@ -3,8 +3,23 @@ import Image from "next/image";
 import { CampaignDisplay } from "@/types/entities/campaign";
 import { generateColorFromString } from "@/utils/colorGenerator";
 import { getInitials } from "@/utils/text";
+import CheckBox from "@/components/general/CheckBox";
 
-export default function CampaignCard({ campaign }: { campaign: CampaignDisplay }) {
+interface CampaignCardProps {
+  campaign: CampaignDisplay;
+  checked: boolean;
+  onCheckboxChange: () => void;
+}
+
+export default function CampaignCard({
+  campaign,
+  checked,
+  onCheckboxChange,
+}: CampaignCardProps) {
+  const handleWrapperClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
   const {
     title,
     vendorName,
@@ -22,45 +37,28 @@ export default function CampaignCard({ campaign }: { campaign: CampaignDisplay }
 
   const [copied, setCopied] = useState(false);
 
-  const getCampaignTypeDisplay = (type?: string) => {
-    switch (type) {
-      case "WalkIn":
-        return "Walk in";
-      case "Delivery":
-        return "Delivery";
-      case "Online":
-        return "Online";
-      case "Exclusive":
-        return "Exclusive";
-      default:
-        return type || "N/A";
-    }
-  };
 
   const getModeIcon = () => {
     if (campaignType === "WalkIn") {
-      return status === 'Approved'
+      return status === "Approved"
         ? "/icons/campaign/card/walk-approved.svg"
         : "/icons/campaign/card/walk-pending-light.svg";
     } else if (campaignType === "Delivery") {
-      return status === 'Approved'
+      return status === "Approved"
         ? "/icons/campaign/card/delivery-approved.svg"
         : "/icons/campaign/card/delivery-pending-light.svg";
     }
-    return status === 'Approved'
+    return status === "Approved"
       ? "/icons/campaign/card/delivery-approved.svg"
       : "/icons/campaign/card/delivery-pending-light.svg";
   };
 
   const getBarterIcon = () => {
-    return status === 'Approved'
+    return status === "Approved"
       ? "/icons/campaign/card/barter-approved.svg"
       : "/icons/campaign/card/barter-pending-light.svg";
   };
 
-  const handleEditClick = () => {
-    console.log("Edit clicked for campaign:", campaign.id);
-  };
 
   const handleCopyClick = () => {
     if (copyLinkUrl) {
@@ -71,10 +69,17 @@ export default function CampaignCard({ campaign }: { campaign: CampaignDisplay }
   };
 
   return (
-    <article className="w-full bg-white rounded-[13px] overflow-hidden">
+    <article className="w-full bg-white rounded-[13px] overflow-hidden relative">
+      <div onClick={handleWrapperClick} className="absolute top-2 right-2 z-10">
+        <CheckBox
+          checked={checked}
+          onChange={onCheckboxChange}
+          onClick={(e) => e.stopPropagation()}
+        />
+      </div>
       <div className="h-[90px] w-full relative bg-[#E1E1E1]">
         <Image
-          src={thumbnailUrl || '/images/no_image.png'}
+          src={thumbnailUrl || "/images/no_image.png"}
           alt={`${title} header`}
           fill
           className="object-cover"
@@ -115,7 +120,11 @@ export default function CampaignCard({ campaign }: { campaign: CampaignDisplay }
           </p>
           <div className="flex gap-[4.5px] items-center">
             <Image
-              src={status === 'Approved' ? "/icons/campaign/card/active-light.svg" : "/icons/campaign/card/pending-light.svg"}
+              src={
+                status === "Approved"
+                  ? "/icons/campaign/card/active-light.svg"
+                  : "/icons/campaign/card/pending-light.svg"
+              }
               alt={status}
               width={11.6}
               height={11.6}
@@ -150,21 +159,21 @@ export default function CampaignCard({ campaign }: { campaign: CampaignDisplay }
               />
             </div>
             <span className="text-[12px] text-[#414141] font-medium">
-              {offerType ?? 'N/A'}
+              {offerType ?? "N/A"}
             </span>
           </div>
           <div className="aspect-square flex flex-col justify-center items-center gap-2 rounded-[11px] bg-white shadow-[0_0_2px_rgba(0,0,0,0.16)]">
             <div className="h-[30.65px] flex items-center justify-center">
               <span
                 className={`text-[21px] font-bold leading-[31px] ${
-                  status === 'Approved' ? "text-[#00A4B6]" : "text-[#505050]"
+                  status === "Approved" ? "text-[#00A4B6]" : "text-[#505050]"
                 }`}
               >
-                {duration ?? 'N/A'}
+                {duration ?? "N/A"}
               </span>
             </div>
             <span className="text-[12px] text-[#414141] font-medium">
-              {durationUnit ?? ''}
+              {durationUnit ?? ""}
             </span>
           </div>
         </div>
@@ -175,9 +184,7 @@ export default function CampaignCard({ campaign }: { campaign: CampaignDisplay }
           >
             {copied ? "Copied!" : "Copy Link"}
           </button>
-          <button
-            onClick={handleEditClick}
-            className="flex-1 bg-[#787878] text-[15px]  text-white py-[9px] rounded-[11px] font-medium leading-[23px]">
+          <button className="flex-1 bg-[#787878] text-[15px]  text-white py-[9px] rounded-[11px] font-medium leading-[23px]">
             Edit
           </button>
         </div>

--- a/src/components/features/campaigns/CampaignsTable.tsx
+++ b/src/components/features/campaigns/CampaignsTable.tsx
@@ -7,14 +7,10 @@ import Link from "next/link";
 
 interface CampaignsTableProps {
   campaigns: CampaignDisplay[];
-  checkedRows: Set<string>;
-  onCheckboxChange: (campaignId: string) => void;
 }
 
 export default function CampaignsTable({
   campaigns,
-  checkedRows,
-  onCheckboxChange,
 }: CampaignsTableProps) {
   const [copiedLink, setCopiedLink] = useState<string | null>(null);
 
@@ -26,20 +22,6 @@ export default function CampaignsTable({
     }
   };
 
-  const getCampaignTypeDisplay = (campaignType?: string) => {
-    switch (campaignType) {
-      case "WalkIn":
-        return "Walk in";
-      case "Delivery":
-        return "Delivery";
-      case "Online":
-        return "Online";
-      case "Exclusive":
-        return "Exclusive";
-      default:
-        return campaignType || "N/A";
-    }
-  };
 
   return (
     <div className="overflow-x-auto">
@@ -48,16 +30,7 @@ export default function CampaignsTable({
           <tr>
             <th
               scope="col"
-              className="pl-3 pr-2 pt-2.5 pb-4 text-left text-lg font-medium text-[#4F4F4F] whitespace-nowrap"
-            >
-              <input
-                type="checkbox"
-                className="h-5 w-5 rounded-md text-blue-600 focus:ring-blue-500"
-              />
-            </th>
-            <th
-              scope="col"
-              className="px-2 pt-2.5 pb-4 text-left text-lg font-medium text-[#4F4F4F] whitespace-nowrap"
+              className="px-2 pt-2.5 pb-4 text-left text-lg font-medium text-[#4F4F4F] whitespace-nowrap pl-8"
             >
               Campaign
             </th>
@@ -103,15 +76,7 @@ export default function CampaignsTable({
         <tbody className="bg-white">
           {campaigns.map((campaign) => (
             <tr key={campaign.id} className="odd:bg-[#F8F8F8]">
-              <td className="pl-3 pr-2 py-2.5 whitespace-nowrap">
-                <input
-                  type="checkbox"
-                  className="h-5 w-5 rounded-md text-blue-600 focus:ring-blue-500"
-                  checked={checkedRows.has(campaign.id.toString())}
-                  onChange={() => onCheckboxChange(campaign.id.toString())}
-                />
-              </td>
-              <td className="px-2 py-2.5 whitespace-nowrap">
+              <td className="px-2 py-2.5 whitespace-nowrap pl-8">
                 <div className="flex items-center">
                   <Link
                     href={`/businesses/campaigns/${campaign.id}`}
@@ -119,15 +84,13 @@ export default function CampaignsTable({
                   >
                     <div className="h-[33px] w-[70px] rounded-[6px] overflow-hidden relative flex-shrink-0">
                       <Image
-                        src={campaign.thumbnailUrl || '/images/no_image.png'}
+                        src={campaign.thumbnailUrl || "/images/no_image.png"}
                         alt={campaign.title}
                         fill
                         className="object-cover"
                       />
                     </div>
-                    <span
-                      className={`ml-3 text-[#4F4F4F]`}
-                    >
+                    <span className={`ml-3 text-[#4F4F4F]`}>
                       {campaign.title}
                     </span>
                   </Link>
@@ -140,7 +103,7 @@ export default function CampaignsTable({
                 {campaign.is_dedicated === 1 ? "Dedicated" : "Normal"}
               </td>
               <td className="px-6 py-2.5 whitespace-nowrap text-[15px] text-[#4F4F4F] text-center">
-                {campaign.offerType ?? 'N/A'}
+                {campaign.offerType ?? "N/A"}
               </td>
               <td className="px-6 py-2.5 whitespace-nowrap text-[13px] text-center">
                 <div
@@ -157,7 +120,12 @@ export default function CampaignsTable({
               </td>
               <td className="px-6 py-2.5 whitespace-nowrap text-[13px] text-center">
                 <button
-                  onClick={() => handleCopyLink(campaign.copyLinkUrl || '', campaign.id.toString())}
+                  onClick={() =>
+                    handleCopyLink(
+                      campaign.copyLinkUrl || "",
+                      campaign.id.toString()
+                    )
+                  }
                   className="w-[110px] px-4.25 py-1 bg-[#00A4B6] text-white rounded-full flex justify-center items-center gap-2"
                 >
                   {copiedLink === campaign.id.toString() ? (


### PR DESCRIPTION
This commit introduces several UI/UX improvements:

1.  **Campaign List UI:**
    - Aligns the campaign card view with the brand card view by adding a checkbox to each `CampaignCard`.
    - Removes the checkbox column from the `CampaignsTable` to streamline the interface.

2.  **Delete Confirmation Toasts:**
    - Implements `react-hot-toast` notifications for delete actions in both the "Accounts" and "Campaigns" pages.
    - Provides users with clear loading, success, and error feedback during the deletion process.