### PR TITLE
feat: Update campaign list UI and add delete confirmations

### DIFF
--- a/src/components/features/campaigns/CampaignCard.tsx
+++ b/src/components/features/campaigns/CampaignCard.tsx
@@ -9,12 +9,14 @@ interface CampaignCardProps {
   campaign: CampaignDisplay;
   checked: boolean;
   onCheckboxChange: () => void;
+  onRemove: (id: string) => void;
 }
 
 export default function CampaignCard({
   campaign,
   checked,
   onCheckboxChange,
+  onRemove,
 }: CampaignCardProps) {
   const handleWrapperClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -60,12 +62,10 @@ export default function CampaignCard({
   };
 
 
-  const handleCopyClick = () => {
-    if (copyLinkUrl) {
-      navigator.clipboard.writeText(copyLinkUrl);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
+  const handleRemoveClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onRemove(campaign.id.toString());
   };
 
   return (
@@ -177,12 +177,15 @@ export default function CampaignCard({
             </span>
           </div>
         </div>
-        <div className="flex">
+        <div className="flex gap-[9px]">
+          <button className="flex-1 bg-[#787878] text-[15px]  text-white py-[9px] rounded-[11px] font-medium leading-[23px]">
+            Edit
+          </button>
           <button
-            onClick={handleCopyClick}
-            className="w-full bg-[#00A4B6] text-[15px] text-white py-[9px] rounded-[11px] font-medium leading-[23px]"
+            onClick={handleRemoveClick}
+            className="flex-1 bg-red-500 text-[15px] text-white py-[9px] rounded-[11px] font-medium leading-[23px]"
           >
-            {copied ? "Copied!" : "Copy Link"}
+            Remove
           </button>
         </div>
       </div>

--- a/src/components/general/dropdowns/ActionDropdown.tsx
+++ b/src/components/general/dropdowns/ActionDropdown.tsx
@@ -5,13 +5,17 @@ import { Dropdown } from "@/components/general/dropdowns/Dropdown";
 interface ActionDropdownProps {
   onSelect?: (value: string) => void;
   disabled?: boolean;
+  showUpdate?: boolean;
+  excludeActions?: string[];
   actions?: string[];
 }
 
 export default function ActionDropdown({
   onSelect,
   disabled,
-  actions = [],
+  showUpdate,
+  excludeActions = [],
+  actions,
 }: ActionDropdownProps) {
   const allPossibleOptions = [
     {
@@ -48,9 +52,21 @@ export default function ActionDropdown({
     },
   ];
 
-  const options = allPossibleOptions.filter((option) =>
-    actions.includes(option.value)
-  );
+  let options = allPossibleOptions;
+
+  if (actions) {
+    options = allPossibleOptions.filter((option) =>
+      actions.includes(option.value)
+    );
+  } else {
+    options = allPossibleOptions.filter(
+      (option) => !excludeActions.includes(option.value)
+    );
+  }
+
+  if (showUpdate === false) {
+    options = options.filter((option) => option.value !== "update");
+  }
 
   const title = (
     <div className="text-[18px] px-6 text-white leading-[27px]">
@@ -69,7 +85,9 @@ export default function ActionDropdown({
       title={title}
       options={options}
       onSelect={handleSelect}
-      buttonClassName={`pt-1.25 pb-1.75 border-0 rounded-[11px] flex items-center justify-between w-full ${disabled ? 'bg-gray-400 cursor-not-allowed' : 'bg-[#00A4B6]'}`}
+      buttonClassName={`pt-1.25 pb-1.75 border-0 rounded-[11px] flex items-center justify-between w-full ${
+        disabled ? "bg-gray-400 cursor-not-allowed" : "bg-[#00A4B6]"
+      }`}
       icon="/icons/general/dropdownarrow-1-white.svg"
       disabled={disabled || options.length === 0}
     />

--- a/src/store/campaigns/CampaignSlice.ts
+++ b/src/store/campaigns/CampaignSlice.ts
@@ -12,6 +12,8 @@ const initialState: CampaignsState = {
   loading: false,
   error: null,
   pagination: null,
+  bulkDeleteLoading: false,
+  bulkDeleteError: null,
 };
 
 const campaignsSlice = createSlice({
@@ -43,18 +45,18 @@ const campaignsSlice = createSlice({
       state,
       action: PayloadAction<{ ids: string[] }>
     ) => {
-      state.loading = true;
-      state.error = null;
+      state.bulkDeleteLoading = true;
+      state.bulkDeleteError = null;
     },
     bulkDeleteCampaignsSuccess: (state, action: PayloadAction<string[]>) => {
-      state.loading = false;
+      state.bulkDeleteLoading = false;
       state.campaigns = state.campaigns.filter(
         (campaign) => !action.payload.includes(campaign.id.toString())
       );
     },
     bulkDeleteCampaignsFailure: (state, action: PayloadAction<any>) => {
-      state.loading = false;
-      state.error = action.payload;
+      state.bulkDeleteLoading = false;
+      state.bulkDeleteError = action.payload;
     },
     getMoreCampaignsStart: (
       state,

--- a/src/types/entities/campaign.ts
+++ b/src/types/entities/campaign.ts
@@ -260,6 +260,8 @@ export interface CampaignsState {
     per_page: number;
     total: number;
   } | null;
+  bulkDeleteLoading: boolean;
+  bulkDeleteError: string | null;
 }
 
 // Unified type for display components


### PR DESCRIPTION
This commit introduces several UI/UX improvements and bug fixes:

1.  **Campaign & Brand List UI:**
    - Aligns the campaign card view with the brand card view by adding a checkbox to each `CampaignCard`.
    - Adds a checkbox to each row in the `CampaignsTable` for selection, while keeping the header clean.
    - Restores navigation functionality to the `CampaignCard` by re-wrapping it in a `Link` component.
    - Adds a "Remove" button to the `CampaignCard` to allow for single-item deletion.
    - Fixes the `ActionDropdown` component to correctly display actions on the accounts and brands pages.

2.  **Delete Confirmation Toasts:**
    - Implements state-driven `react-hot-toast` notifications for delete actions in both the "Accounts" and "Campaigns" pages, providing users with clear loading, success, and error feedback.

3.  **Redux Refactoring:**
    - Refactors the campaign deletion logic to use a `bulkDeleteCampaigns` action and saga.
    - Adds specific loading and error states to the Redux store for more reliable, state-driven toast notifications.