### PR TITLE
feat: Implement creator approval and rejection functionality

### DIFF
--- a/src/app/(features)/businesses/brands/[brandId]/page.tsx
+++ b/src/app/(features)/businesses/brands/[brandId]/page.tsx
@@ -138,7 +138,7 @@ export default function BrandPage() {
   useEffect(() => {
     if (prevBulkDeleteLoading && !bulkDeleteLoading) {
       if (bulkDeleteError) {
-        toast.error(bulkDeleteError.message || "Failed to delete campaign.");
+        toast.error(bulkDeleteError || "Failed to delete campaign.");
       } else {
         toast.success("Campaign deleted successfully.");
         if (brandId) {

--- a/src/services/commonService.tsx
+++ b/src/services/commonService.tsx
@@ -68,5 +68,8 @@ export const updateCreatorStatus = async (
   status: number,
   rejectReason?: string
 ) => {
-  return await postData(`/dedicated/${id}/status`, { status, rejectReason });
+  return await postData(`/api/dedicated/${id}/status`, {
+    status,
+    rejectReason,
+  });
 };


### PR DESCRIPTION
This commit introduces the following changes to the campaign creators tab:

- Binds creator data from the API response, including name, Instagram URL, followers, and credibility.
- Displays the first two initials of the creator's name as a fallback if no profile picture is available.
- Implements approve and reject actions for creators, calling the `/api/dedicated/{id}/status` endpoint.
- Adds a modal to capture the reason for rejection.
- Comments out the "Engagement" metric as requested.

fix: Replace react-toastify with react-hot-toast to resolve build error.
fix: Correct error handling for campaign deletion to resolve build error.