### PR TITLE
fix: Safely handle optional onRemoveCampaign prop

### DIFF
--- a/src/components/features/brands/BrandCampaigns.tsx
+++ b/src/components/features/brands/BrandCampaigns.tsx
@@ -60,7 +60,9 @@ export default function BrandCampaigns({
             >
               <CampaignCard
                 campaign={campaign}
-                onRemove={() => onRemoveCampaign(campaign.id.toString())}
+                onRemove={() =>
+                  onRemoveCampaign && onRemoveCampaign(campaign.id.toString())
+                }
                 checked={false}
                 onCheckboxChange={() => {}}
               />
@@ -77,7 +79,9 @@ export default function BrandCampaigns({
           >
             <BrandCampaignMobileCard
               campaign={campaign}
-              onRemove={() => onRemoveCampaign(campaign.id.toString())}
+              onRemove={() =>
+                onRemoveCampaign && onRemoveCampaign(campaign.id.toString())
+              }
             />
           </div>
         ))}


### PR DESCRIPTION
This commit fixes a TypeError that occurred when the `onRemoveCampaign` prop was not provided to the `BrandCampaigns` component. The `onRemove` handlers for `CampaignCard` and `BrandCampaignMobileCard` now check for the existence of `onRemoveCampaign` before invoking it, preventing runtime errors.