### PR TITLE
fix: Resolve all cascading errors and update creator ID logic

### DIFF
--- a/src/app/(features)/businesses/brands/[brandId]/page.tsx
+++ b/src/app/(features)/businesses/brands/[brandId]/page.tsx
@@ -123,18 +123,6 @@ export default function BrandPage() {
 
   const [prevBulkDeleteLoading, setPrevBulkDeleteLoading] = useState(false);
 
-  if (loading) {
-    return <Loader />;
-  }
-
-  if (error && !isCreateMode) {
-    return <p className="text-red-500 text-center py-10">Error: {error}</p>;
-  }
-
-  if (!brand && !isCreateMode) {
-    return <Loader />;
-  }
-
   useEffect(() => {
     if (prevBulkDeleteLoading && !bulkDeleteLoading) {
       if (bulkDeleteError) {
@@ -148,6 +136,18 @@ export default function BrandPage() {
     }
     setPrevBulkDeleteLoading(bulkDeleteLoading);
   }, [bulkDeleteLoading, bulkDeleteError, prevBulkDeleteLoading, brandId, dispatch]);
+
+  if (loading) {
+    return <Loader />;
+  }
+
+  if (error && !isCreateMode) {
+    return <p className="text-red-500 text-center py-10">Error: {error}</p>;
+  }
+
+  if (!brand && !isCreateMode) {
+    return <Loader />;
+  }
 
   const handleRemoveCampaign = (campaignId: string) => {
     toast(


### PR DESCRIPTION
This commit addresses a series of cascading TypeScript errors, a React hook runtime error, and a logic error in creator management. The fixes include:

1.  **Logic Correction:** Corrected the ID used in `Creators.tsx` to be the `offer_user.id` instead of the nested `user.id` for approve/reject actions.
2.  **React Hook Fix:** Resolved a "Rendered more hooks than during the previous render" error in `BrandPage` by moving all hooks to the top level of the component.
3.  **Cascading Type Errors:**
    - Added a null check for an optional function prop in `BrandCampaigns.tsx`.
    - Defined and exported a missing `OfferUser` type and added the `dedicated_offer` property to the `Campaign` type.
    - Added the `is_dedicated` property to the `CampaignDisplay` type in `campaignAdapters.ts`.
    - Updated the `ApiAccount` type in `src/types/auth.ts` to include the `food_offers_count` property.
    - Updated mock data in `AccountsData.ts` and `BrandsData.ts` to include the required `food_offers_count` property.
    - Updated data transformation functions in `accountSaga.ts`, `authSaga.ts`, `brandSaga.ts`, and `brandUtils.ts` to include the `food_offers_count` property.
    - Updated the `initializeNewBrand` reducer in `brandSlice.ts` to include the `food_offers_count` property.
    - Added a backward compatibility check in `AuthInitializer.tsx` to handle old user data in localStorage.
    - Fixed an incorrect import for `PayloadAction` in `CampaignSaga.ts`.