### PR TITLE
fix: Resolve all cascading errors and implement creator status feature

### DIFF
--- a/src/store/campaigns/CampaignSlice.ts
+++ b/src/store/campaigns/CampaignSlice.ts
@@ -14,6 +14,9 @@ const initialState: CampaignsState = {
   pagination: null,
   bulkDeleteLoading: false,
   bulkDeleteError: null,
+  dedicatedPageStatusLoading: false,
+  dedicatedPageStatusSuccess: false,
+  dedicatedPageStatusError: null,
 };
 
 const campaignsSlice = createSlice({
@@ -104,15 +107,22 @@ const campaignsSlice = createSlice({
       state.error = action.payload;
     },
     updateDedicatedPageStatusStart: (state,action: PayloadAction<{ id: string; status: number; rejectReason?: string }>) => {
-      state.loading = true;
-      state.error = null;
+      state.dedicatedPageStatusLoading = true;
+      state.dedicatedPageStatusSuccess = false;
+      state.dedicatedPageStatusError = null;
     },
     updateDedicatedPageStatusSuccess: (state) => {
-      state.loading = false;
+      state.dedicatedPageStatusLoading = false;
+      state.dedicatedPageStatusSuccess = true;
     },
     updateDedicatedPageStatusFailure: (state, action) => {
-      state.loading = false;
-      state.error = action.payload;
+      state.dedicatedPageStatusLoading = false;
+      state.dedicatedPageStatusError = action.payload;
+    },
+    resetDedicatedPageStatus: (state) => {
+      state.dedicatedPageStatusLoading = false;
+      state.dedicatedPageStatusSuccess = false;
+      state.dedicatedPageStatusError = null;
     },
   },
 });
@@ -132,6 +142,7 @@ export const {
   updateDedicatedPageStatusStart,
   updateDedicatedPageStatusSuccess,
   updateDedicatedPageStatusFailure,
+  resetDedicatedPageStatus,
   bulkDeleteCampaignsStart,
   bulkDeleteCampaignsSuccess,
   bulkDeleteCampaignsFailure,

--- a/src/types/entities/campaign.ts
+++ b/src/types/entities/campaign.ts
@@ -280,6 +280,9 @@ export interface CampaignsState {
   } | null;
   bulkDeleteLoading: boolean;
   bulkDeleteError: string | null;
+  dedicatedPageStatusLoading: boolean;
+  dedicatedPageStatusSuccess: boolean;
+  dedicatedPageStatusError: string | null;
 }
 
 // Unified type for display components


### PR DESCRIPTION
This commit addresses a series of cascading TypeScript errors, a React hook runtime error, a logic error in creator management, and implements a new feature for creator approval/rejection feedback.

The fixes and features include:

1.  **Feature:** Implemented toast notifications for creator approval/rejection actions using `react-hot-toast`.
2.  **Feature:** Added specific Redux state management for the creator status update action to support the new toast notifications.
3.  **Logic Correction:** Corrected the ID used in `Creators.tsx` to be the `offer_user.id` instead of the nested `user.id` for approve/reject actions.
4.  **React Hook Fix:** Resolved a "Rendered more hooks than during the previous render" error in `BrandPage` by moving all hooks to the top level of the component.
5.  **Cascading Type Errors:**
    - Added a null check for an optional function prop in `BrandCampaigns.tsx`.
    - Defined and exported a missing `OfferUser` type and added the `dedicated_offer` property to the `Campaign` type.
    - Added the `is_dedicated` property to the `CampaignDisplay` type in `campaignAdapters.ts`.
    - Updated the `ApiAccount` type in `src/types/auth.ts` to include the `food_offers_count` property.
    - Updated mock data in `AccountsData.ts` and `BrandsData.ts` to include the required `food_offers_count` property.
    - Updated data transformation functions in `accountSaga.ts`, `authSaga.ts`, `brandSaga.ts`, and `brandUtils.ts` to include the `food_offers_count` property.
    - Updated the `initializeNewBrand` reducer in `brandSlice.ts` to include the `food_offers_count` property.
    - Added a backward compatibility check in `AuthInitializer.tsx` to handle old user data in localStorage.
    - Fixed an incorrect import for `PayloadAction` in `CampaignSaga.ts`.