### PR TITLE
Fix: Campaign and creator status updates

### DIFF
--- a/src/components/features/campaigns/tabs/Creators/CampaignCreatorCard.tsx
+++ b/src/components/features/campaigns/tabs/Creators/CampaignCreatorCard.tsx
@@ -10,7 +10,7 @@ interface CampaignCreatorCardProps {
     credibility: string;
     engagement: string;
   };
-  approved?: boolean;
+  status: number | null;
   onApprove: (id: string) => void;
   onReject: (id: string) => void;
   loading?: boolean;
@@ -22,7 +22,7 @@ export default function CampaignCreatorCard({
   name,
   instagramName,
   stats,
-  approved = false,
+  status,
   onApprove,
   onReject,
   loading = false,
@@ -109,10 +109,10 @@ export default function CampaignCreatorCard({
           </div> */}
         </div>
 
-        {/* Action buttons or Approved text */}
+        {/* Action buttons or status text */}
         <div className="flex md:gap-[9px] gap-2 md:pb-[9px] md:pl-[9px] md:pr-[9px] pr-3">
-          {approved ? (
-            <div className="flex-1 flex items-center md:justify-center gap-2  text-[#00A4B6] py-[7px] md:rounded-[13px] rounded-[11px]  text-[13px] leading-[20px] font-medium h-[38px]">
+          {status === 1 ? (
+            <div className="flex-1 flex items-center md:justify-center gap-2 text-[#00A4B6] py-[7px] md:rounded-[13px] rounded-[11px] text-[13px] leading-[20px] font-medium h-[38px]">
               <Image
                 src="/icons/campaign/details/creators-and-posts/verified-check.svg"
                 alt="Approved"
@@ -120,6 +120,10 @@ export default function CampaignCreatorCard({
                 height={9.09}
               />
               <p>Approved</p>
+            </div>
+          ) : status === 0 ? (
+            <div className="flex-1 flex items-center md:justify-center gap-2 text-red-500 py-[7px] md:rounded-[13px] rounded-[11px] text-[13px] leading-[20px] font-medium h-[38px]">
+              <p>Rejected</p>
             </div>
           ) : (
             <>

--- a/src/store/campaigns/CampaignSaga.ts
+++ b/src/store/campaigns/CampaignSaga.ts
@@ -64,6 +64,7 @@ function* updateCampaignStatusSaga(action: UpdateCampaignStatusAction) {
     }
     yield call(axiosInstance.post, `/api/campaign/${id}/status`, payload);
     yield put(updateCampaignStatusSuccess());
+    yield put(getCampaignDetailsStart({ id }));
   } catch (error: any) {
     yield put(updateCampaignStatusFailure(error.message));
   }
@@ -86,9 +87,16 @@ function* updateDedicatedPageStatusSaga(
   action: UpdateDedicatedPageStatusAction
 ) {
   try {
-    const { id, ...payload } = action.payload;
+    const { id, status, rejectReason, campaignId } = action.payload;
+    const payload: { status: number; rejectReason?: string } = { status };
+    if (rejectReason) {
+      payload.rejectReason = rejectReason;
+    }
     yield call(axiosInstance.post, `/api/dedicated/${id}/status`, payload);
     yield put(updateDedicatedPageStatusSuccess());
+    if (campaignId) {
+      yield put(getCampaignDetailsStart({ id: campaignId }));
+    }
   } catch (error: any) {
     yield put(updateDedicatedPageStatusFailure(error.message));
   }


### PR DESCRIPTION
This commit fixes issues related to campaign and creator status updates on the campaign details page.

- After a campaign or creator is approved or rejected, the UI now updates automatically without requiring a page reload. This is achieved by re-fetching the campaign details after a successful status update.
- The creator's status is now correctly displayed as "Approved", "Rejected", or with action buttons based on the `offerUser.status` value.