### PR TITLE
Fix: Campaign and creator status updates

### DIFF
--- a/src/store/campaigns/CampaignSlice.ts
+++ b/src/store/campaigns/CampaignSlice.ts
@@ -15,7 +15,7 @@ const initialState: CampaignsState = {
   bulkDeleteLoading: false,
   bulkDeleteError: null,
   dedicatedPageStatusLoading: false,
-  dedicatedPageStatusSuccess: false,
+  dedicatedPageStatusSuccess: null,
   dedicatedPageStatusError: null,
 };
 
@@ -106,22 +106,24 @@ const campaignsSlice = createSlice({
       state.loading = false;
       state.error = action.payload;
     },
-    updateDedicatedPageStatusStart: (state,action: PayloadAction<{ id: string; status: number; rejectReason?: string }>) => {
+    updateDedicatedPageStatusStart: (
+      state,
+      action: PayloadAction<UpdateDedicatedPageStatusPayload>
+    ) => {
       state.dedicatedPageStatusLoading = true;
-      state.dedicatedPageStatusSuccess = false;
+      state.dedicatedPageStatusSuccess = null;
       state.dedicatedPageStatusError = null;
     },
     updateDedicatedPageStatusSuccess: (state) => {
       state.dedicatedPageStatusLoading = false;
-      state.dedicatedPageStatusSuccess = true;
+      state.dedicatedPageStatusSuccess = { timestamp: Date.now() };
     },
     updateDedicatedPageStatusFailure: (state, action) => {
       state.dedicatedPageStatusLoading = false;
       state.dedicatedPageStatusError = action.payload;
     },
     resetDedicatedPageStatus: (state) => {
-      state.dedicatedPageStatusLoading = false;
-      state.dedicatedPageStatusSuccess = false;
+      state.dedicatedPageStatusSuccess = null;
       state.dedicatedPageStatusError = null;
     },
   },

--- a/src/types/entities/campaign.ts
+++ b/src/types/entities/campaign.ts
@@ -223,6 +223,7 @@ export interface UpdateDedicatedPageStatusPayload {
   id: string;
   status: 0 | 1;
   rejectReason?: string;
+  campaignId?: string;
 }
 
 // API Responses
@@ -281,7 +282,7 @@ export interface CampaignsState {
   bulkDeleteLoading: boolean;
   bulkDeleteError: string | null;
   dedicatedPageStatusLoading: boolean;
-  dedicatedPageStatusSuccess: boolean;
+  dedicatedPageStatusSuccess: { timestamp: number } | null;
   dedicatedPageStatusError: string | null;
 }
 


### PR DESCRIPTION
This commit fixes issues related to campaign and creator status updates on the campaign details page.

- After a campaign or creator is approved or rejected, the UI now updates automatically without requiring a page reload. This is achieved by re-fetching the campaign details after a successful status update.
- The creator's status is now correctly displayed as "Approved", "Rejected", or with action buttons based on the `offerUser.status` value.
- The issue of multiple toast notifications appearing for creator status updates has been resolved by changing the Redux state to use a timestamp for success events.