### PR TITLE
Fix: Optimize campaign and creator status updates

### DIFF
--- a/src/components/features/campaigns/tabs/Creators.tsx
+++ b/src/components/features/campaigns/tabs/Creators.tsx
@@ -1,16 +1,12 @@
 "use client";
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { Campaign, OfferUser } from "@/types/entities";
 import CampaignCreatorCard from "./Creators/CampaignCreatorCard";
 import Pagination from "@/components/general/Pagination";
 import { useDispatch, useSelector } from "react-redux";
-import {
-  updateDedicatedPageStatusStart,
-  resetDedicatedPageStatus,
-} from "@/store/campaigns/CampaignSlice";
+import { updateDedicatedPageStatusStart } from "@/store/campaigns/CampaignSlice";
 import { RootState } from "@/store/store";
 import RejectReasonModal from "../RejectReasonModal";
-import toast from "react-hot-toast";
 
 const ITEMS_PER_PAGE = 6;
 
@@ -22,26 +18,18 @@ export default function Creators({ campaign }: { campaign: Campaign }) {
   );
   const [isRejectModalOpen, setIsRejectModalOpen] = useState(false);
 
-  const {
-    dedicatedPageStatusLoading,
-    dedicatedPageStatusSuccess,
-    dedicatedPageStatusError,
-  } = useSelector((state: RootState) => state.campaigns);
+  const { dedicatedPageStatusLoading } = useSelector(
+    (state: RootState) => state.campaigns
+  );
+  const prevLoading = useRef(dedicatedPageStatusLoading);
 
   useEffect(() => {
-    if (dedicatedPageStatusSuccess) {
-      toast.success("Creator status updated successfully!");
+    if (prevLoading.current && !dedicatedPageStatusLoading) {
       setIsRejectModalOpen(false);
       setSelectedCreatorId(null);
-      dispatch(resetDedicatedPageStatus());
     }
-    if (dedicatedPageStatusError) {
-      toast.error(
-        dedicatedPageStatusError || "Failed to update creator status."
-      );
-      dispatch(resetDedicatedPageStatus());
-    }
-  }, [dedicatedPageStatusSuccess, dedicatedPageStatusError, dispatch]);
+    prevLoading.current = dedicatedPageStatusLoading;
+  }, [dedicatedPageStatusLoading]);
 
   const creators = campaign?.dedicated_offer?.offer_users || [];
 
@@ -69,13 +57,7 @@ export default function Creators({ campaign }: { campaign: Campaign }) {
 
   const handleApprove = (id: string) => {
     setSelectedCreatorId(id);
-    dispatch(
-      updateDedicatedPageStatusStart({
-        id: id,
-        status: 1,
-        campaignId: campaign.id.toString(),
-      })
-    );
+    dispatch(updateDedicatedPageStatusStart({ id: id, status: 1 }));
   };
 
   const handleReject = (id: string) => {
@@ -90,7 +72,6 @@ export default function Creators({ campaign }: { campaign: Campaign }) {
         id: selectedCreatorId,
         status: 0,
         rejectReason: rejectReason,
-        campaignId: campaign.id.toString(),
       })
     );
   };

--- a/src/store/campaigns/CampaignSaga.ts
+++ b/src/store/campaigns/CampaignSaga.ts
@@ -1,5 +1,6 @@
 import { call, put, takeLatest, all } from "redux-saga/effects";
 import { PayloadAction } from "@reduxjs/toolkit";
+import toast from "react-hot-toast";
 import axiosInstance from "../../services/apiHelper";
 import {
   getCampaignsStart,
@@ -63,8 +64,7 @@ function* updateCampaignStatusSaga(action: UpdateCampaignStatusAction) {
       payload.rejectReason = rejectReason;
     }
     yield call(axiosInstance.post, `/api/campaign/${id}/status`, payload);
-    yield put(updateCampaignStatusSuccess());
-    yield put(getCampaignDetailsStart({ id }));
+    yield put(updateCampaignStatusSuccess({ status }));
   } catch (error: any) {
     yield put(updateCampaignStatusFailure(error.message));
   }
@@ -87,18 +87,19 @@ function* updateDedicatedPageStatusSaga(
   action: UpdateDedicatedPageStatusAction
 ) {
   try {
-    const { id, status, rejectReason, campaignId } = action.payload;
+    const { id, status, rejectReason } = action.payload;
     const payload: { status: number; rejectReason?: string } = { status };
     if (rejectReason) {
       payload.rejectReason = rejectReason;
     }
     yield call(axiosInstance.post, `/api/dedicated/${id}/status`, payload);
-    yield put(updateDedicatedPageStatusSuccess());
-    if (campaignId) {
-      yield put(getCampaignDetailsStart({ id: campaignId }));
-    }
+    yield put(updateDedicatedPageStatusSuccess({ id, status }));
+    toast.success("Creator status updated successfully!");
   } catch (error: any) {
-    yield put(updateDedicatedPageStatusFailure(error.message));
+    const errorMessage =
+      error.response?.data?.message || "Failed to update creator status.";
+    yield put(updateDedicatedPageStatusFailure(errorMessage));
+    toast.error(errorMessage);
   }
 }
 

--- a/src/store/campaigns/CampaignSlice.ts
+++ b/src/store/campaigns/CampaignSlice.ts
@@ -15,8 +15,6 @@ const initialState: CampaignsState = {
   bulkDeleteLoading: false,
   bulkDeleteError: null,
   dedicatedPageStatusLoading: false,
-  dedicatedPageStatusSuccess: null,
-  dedicatedPageStatusError: null,
 };
 
 const campaignsSlice = createSlice({
@@ -84,8 +82,14 @@ const campaignsSlice = createSlice({
       state.loading = true;
       state.error = null;
     },
-    updateCampaignStatusSuccess: (state) => {
+    updateCampaignStatusSuccess: (
+      state,
+      action: PayloadAction<{ status: string }>
+    ) => {
       state.loading = false;
+      if (state.campaign) {
+        state.campaign.account_status = action.payload.status;
+      }
     },
     updateCampaignStatusFailure: (state, action) => {
       state.loading = false;
@@ -111,20 +115,23 @@ const campaignsSlice = createSlice({
       action: PayloadAction<UpdateDedicatedPageStatusPayload>
     ) => {
       state.dedicatedPageStatusLoading = true;
-      state.dedicatedPageStatusSuccess = null;
-      state.dedicatedPageStatusError = null;
     },
-    updateDedicatedPageStatusSuccess: (state) => {
+    updateDedicatedPageStatusSuccess: (
+      state,
+      action: PayloadAction<{ id: string; status: number }>
+    ) => {
       state.dedicatedPageStatusLoading = false;
-      state.dedicatedPageStatusSuccess = { timestamp: Date.now() };
+      if (state.campaign && state.campaign.dedicated_offer) {
+        const offerUser = state.campaign.dedicated_offer.offer_users.find(
+          (user) => user.id.toString() === action.payload.id
+        );
+        if (offerUser) {
+          offerUser.status = action.payload.status;
+        }
+      }
     },
     updateDedicatedPageStatusFailure: (state, action) => {
       state.dedicatedPageStatusLoading = false;
-      state.dedicatedPageStatusError = action.payload;
-    },
-    resetDedicatedPageStatus: (state) => {
-      state.dedicatedPageStatusSuccess = null;
-      state.dedicatedPageStatusError = null;
     },
   },
 });
@@ -144,7 +151,6 @@ export const {
   updateDedicatedPageStatusStart,
   updateDedicatedPageStatusSuccess,
   updateDedicatedPageStatusFailure,
-  resetDedicatedPageStatus,
   bulkDeleteCampaignsStart,
   bulkDeleteCampaignsSuccess,
   bulkDeleteCampaignsFailure,

--- a/src/types/entities/campaign.ts
+++ b/src/types/entities/campaign.ts
@@ -282,8 +282,6 @@ export interface CampaignsState {
   bulkDeleteLoading: boolean;
   bulkDeleteError: string | null;
   dedicatedPageStatusLoading: boolean;
-  dedicatedPageStatusSuccess: { timestamp: number } | null;
-  dedicatedPageStatusError: string | null;
 }
 
 // Unified type for display components


### PR DESCRIPTION
This commit resolves multiple issues related to campaign and creator status updates on the campaign details page, focusing on performance and reliability.

- The UI now updates instantly after a campaign or creator is approved or rejected. This is achieved by updating the local Redux state directly instead of re-fetching data from the server, which eliminates the previous slowness.
- The creator's status is now correctly displayed as "Approved", "Rejected", or with action buttons based on the `offerUser.status` value.
- The issue of multiple toast notifications for creator status updates has been resolved by moving the notification logic into the Redux saga, ensuring it fires exactly once per event.
- Unnecessary Redux state properties have been removed to simplify the codebase.