### PR TITLE
Feat: Implement Image Slider for Campaign Posts

### DIFF
--- a/src/components/features/campaigns/tabs/Posts/ImageSliderModal.tsx
+++ b/src/components/features/campaigns/tabs/Posts/ImageSliderModal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Dialog } from "@headlessui/react";
 import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css";
@@ -19,25 +21,55 @@ export default function ImageSliderModal({
   images,
   initialSlide,
 }: ImageSliderModalProps) {
+  if (!isOpen) {
+    return null;
+  }
+
   return (
-    <Dialog open={isOpen} onClose={onClose} className="relative z-50">
-      <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
+    <Dialog
+      open={isOpen}
+      onClose={onClose}
+      className="relative z-50"
+    >
+      {/* The backdrop, rendered as a fixed sibling to the panel container */}
+      <div className="fixed inset-0 bg-black/70" aria-hidden="true" />
+
+      {/* Full-screen container to center the panel */}
       <div className="fixed inset-0 flex items-center justify-center p-4">
-        <Dialog.Panel className="w-full max-w-3xl rounded bg-white p-4">
+        <Dialog.Panel className="w-full max-w-4xl h-full max-h-[90vh] rounded-lg bg-white p-2 relative">
+          <button
+            onClick={onClose}
+            className="absolute top-2 right-2 z-10 bg-white rounded-full p-1 text-gray-500 hover:text-gray-800"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-6 w-6"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
           <Swiper
             modules={[Navigation, Pagination]}
             navigation
             pagination={{ clickable: true }}
             initialSlide={initialSlide}
+            className="w-full h-full"
           >
             {images.map((image, index) => (
-              <SwiperSlide key={index}>
-                <div className="flex justify-center items-center">
+              <SwiperSlide key={index} className="flex items-center justify-center">
+                <div className="relative w-full h-full">
                   <Image
                     src={image}
                     alt={`Post image ${index + 1}`}
-                    width={800}
-                    height={600}
+                    fill
                     className="object-contain"
                   />
                 </div>


### PR DESCRIPTION
- Adds an image slider for posts with more than three images.
- Creates a new `ImageSliderModal` component using Swiper.js with an improved, cleaner UI.
- Displays an overlay on the third image with a count of remaining images when there are more than three.
- Refactors image handling to use the `public` directory for static assets, which is a more standard approach in Next.js.
- Resolves an image loading issue by moving creator avatars to the `public` directory and updating their paths in the data source.