### PR TITLE
feat: Add Campaign Request page

### DIFF
--- a/public/icons/sidebar/campaign-request.svg
+++ b/public/icons/sidebar/campaign-request.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebdf4a115a9ff6a41969039c7089de1b20b25808fa6b646ce1256dcd5d2af9c5
+size 2684

--- a/src/app/(features)/businesses/campaign-request/page.tsx
+++ b/src/app/(features)/businesses/campaign-request/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import React from "react";
+
+const CampaignRequestPage = () => {
+  return (
+    <div className="h-full">
+      <iframe
+        src="https://business.alist.ae/forms/campaign-details"
+        className="w-full h-full border-0"
+      />
+    </div>
+  );
+};
+
+export default CampaignRequestPage;

--- a/src/utils/sidebar-config.ts
+++ b/src/utils/sidebar-config.ts
@@ -64,6 +64,16 @@ export const sidebarConfig: SidebarSection[] = [
         label: "Campaigns",
         href: "/businesses/campaigns",
       },
+      {
+        icon: {
+          src: "/icons/sidebar/campaign-request.svg",
+          alt: "Campaign Request",
+          width: 24.14,
+          height: 24.12,
+        },
+        label: "Campaign Request",
+        href: "/businesses/campaign-request",
+      },
       // {
       //   icon: {
       //     src: "/icons/sidebar/activities.svg",


### PR DESCRIPTION
This commit introduces a new "Campaign Request" page to the application.

- A new menu item has been added to the sidebar under the "Businesses" section.
- The "Campaign Request" page displays content from an external URL within an iframe.
- A new icon has been created for the menu item.