### PR TITLE
feat: Implement campaign review posts tab

### DIFF
--- a/src/store/campaigns/CampaignSaga.ts
+++ b/src/store/campaigns/CampaignSaga.ts
@@ -20,11 +20,16 @@ import {
   bulkDeleteCampaignsStart,
   bulkDeleteCampaignsSuccess,
   bulkDeleteCampaignsFailure,
+  getReviewPostsStart,
+  getReviewPostsSuccess,
+  getReviewPostsFailure,
 } from "./CampaignSlice";
 import {
   CampaignsApiResponse,
   CampaignDetailsApiResponse,
+  CampaignReviewPostsResponse,
   GetCampaignsAction,
+  GetCampaignReviewPostsAction,
   UpdateCampaignStatusAction,
   GetCampaignDetailsAction,
   UpdateDedicatedPageStatusAction,
@@ -118,6 +123,19 @@ function* bulkDeleteCampaignsSaga(action: PayloadAction<{ ids: string[] }>) {
   }
 }
 
+function* getCampaignReviewPostsSaga(action: GetCampaignReviewPostsAction) {
+  try {
+    const { id, page = 1, per_page = 12 } = action.payload;
+    const response: CampaignReviewPostsResponse = yield call(
+      axiosInstance.get,
+      `/api/campaign/review-posts/${id}?page=${page}&per_page=${per_page}`
+    );
+    yield put(getReviewPostsSuccess(response.data));
+  } catch (error: any) {
+    yield put(getReviewPostsFailure(error.message));
+  }
+}
+
 function* watchCampaigns() {
   yield takeLatest(getCampaignsStart.type, getCampaignsSaga);
   yield takeLatest(getMoreCampaignsStart.type, getMoreCampaignsSaga);
@@ -128,6 +146,7 @@ function* watchCampaigns() {
     updateDedicatedPageStatusSaga
   );
   yield takeLatest(bulkDeleteCampaignsStart.type, bulkDeleteCampaignsSaga);
+  yield takeLatest(getReviewPostsStart.type, getCampaignReviewPostsSaga);
 }
 
 export default function* campaignsSaga() {

--- a/src/store/campaigns/CampaignSlice.ts
+++ b/src/store/campaigns/CampaignSlice.ts
@@ -3,6 +3,7 @@ import {
   CampaignsState,
   GetCampaignsPayload,
   GetCampaignDetailsPayload,
+  GetCampaignReviewPostsPayload,
   UpdateCampaignStatusPayload,
   UpdateDedicatedPageStatusPayload,
 } from '../../types/entities/campaign';
@@ -17,6 +18,10 @@ const initialState: CampaignsState = {
   bulkDeleteError: null,
   dedicatedPageStatusLoading: false,
   statusUpdateLoading: false,
+  reviewPosts: [],
+  reviewPostsLoading: false,
+  reviewPostsError: null,
+  reviewPostsPagination: null,
 };
 
 const campaignsSlice = createSlice({
@@ -135,6 +140,27 @@ const campaignsSlice = createSlice({
     updateDedicatedPageStatusFailure: (state, action) => {
       state.dedicatedPageStatusLoading = false;
     },
+    getReviewPostsStart: (
+      state,
+      action: PayloadAction<GetCampaignReviewPostsPayload>
+    ) => {
+      state.reviewPostsLoading = true;
+      state.reviewPostsError = null;
+    },
+    getReviewPostsSuccess: (state, action) => {
+      state.reviewPostsLoading = false;
+      state.reviewPosts = action.payload.data;
+      state.reviewPostsPagination = {
+        current_page: action.payload.current_page,
+        last_page: action.payload.last_page,
+        per_page: action.payload.per_page,
+        total: action.payload.total,
+      };
+    },
+    getReviewPostsFailure: (state, action) => {
+      state.reviewPostsLoading = false;
+      state.reviewPostsError = action.payload;
+    },
   },
 });
 
@@ -156,6 +182,9 @@ export const {
   bulkDeleteCampaignsStart,
   bulkDeleteCampaignsSuccess,
   bulkDeleteCampaignsFailure,
+  getReviewPostsStart,
+  getReviewPostsSuccess,
+  getReviewPostsFailure,
 } = campaignsSlice.actions;
 
 export default campaignsSlice.reducer;

--- a/src/types/entities/campaign.ts
+++ b/src/types/entities/campaign.ts
@@ -267,6 +267,44 @@ export interface UpdateDedicatedPageStatusAction {
   payload: UpdateDedicatedPageStatusPayload;
 }
 
+// Campaign Review Post Types
+export interface CampaignReviewPostUser {
+  name: string;
+  instagram_url: string | null;
+  instagram_followers: number | null;
+}
+
+export interface CampaignReviewPost {
+  id: number;
+  rating: number; // to be used as reach
+  screenshot1: string | null;
+  screenshot2: string | null;
+  screenshot3: string | null;
+  screenshot4: string | null;
+  user: CampaignReviewPostUser;
+}
+
+export interface CampaignReviewPostsResponse {
+  data: {
+    data: CampaignReviewPost[];
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+  };
+}
+
+export interface GetCampaignReviewPostsPayload {
+  id: string;
+  page?: number;
+  per_page?: number;
+}
+
+export interface GetCampaignReviewPostsAction {
+  type: string;
+  payload: GetCampaignReviewPostsPayload;
+}
+
 // Redux State
 export interface CampaignsState {
   campaigns: CampaignSummary[];
@@ -283,6 +321,15 @@ export interface CampaignsState {
   bulkDeleteError: string | null;
   dedicatedPageStatusLoading: boolean;
   statusUpdateLoading: boolean;
+  reviewPosts: CampaignReviewPost[];
+  reviewPostsLoading: boolean;
+  reviewPostsError: string | null;
+  reviewPostsPagination: {
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+  } | null;
 }
 
 // Unified type for display components


### PR DESCRIPTION
This commit introduces the functionality to display campaign review posts in the campaign details page.

- Adds Redux state, actions, and a saga to fetch campaign review posts from the `/api/campaign/review-posts/{id}` endpoint.
- Updates the "Posts" tab in the campaign details page to display the fetched posts, including user information, followers, reach, and images.
- Implements pagination for the review posts.
- Formats follower and reach numbers to be displayed in "K" format when over 1000.