### PR TITLE
fix: Correct data mapping for campaign review posts

### DIFF
--- a/src/store/campaigns/CampaignSaga.ts
+++ b/src/store/campaigns/CampaignSaga.ts
@@ -126,12 +126,12 @@ function* bulkDeleteCampaignsSaga(action: PayloadAction<{ ids: string[] }>) {
 function* getCampaignReviewPostsSaga(action: GetCampaignReviewPostsAction) {
   try {
     const { id, page = 1, per_page = 10 } = action.payload;
-    const response: CampaignReviewPostsResponse = yield call(
+    const response: { data: CampaignReviewPostsResponse } = yield call(
       axiosInstance.post,
       `/api/campaign/review-posts/${id}`,
       { page, per_page }
     );
-    yield put(getReviewPostsSuccess(response.data));
+    yield put(getReviewPostsSuccess(response.data.data));
   } catch (error: any) {
     yield put(getReviewPostsFailure(error.message));
   }


### PR DESCRIPTION
This commit resolves a runtime error (`reviewPosts.map is not a function`) that occurred on the campaign details page. The error was caused by an incorrect data structure being passed to the Redux reducer.

- The `getCampaignReviewPostsSaga` has been updated to correctly extract the nested `data` object from the API response before passing it to the success action.
- This ensures that the `reviewPosts` state is always an array, as expected by the UI component.