### PR TITLE
feat: Implement campaign review posts with full image URLs

### DIFF
--- a/src/components/features/campaigns/tabs/Posts.tsx
+++ b/src/components/features/campaigns/tabs/Posts.tsx
@@ -59,15 +59,22 @@ export default function Posts({ campaign }: PostsProps) {
   }
 
   const mappedPosts = reviewPosts.map((post: CampaignReviewPost) => {
+    const imageUrlBase = process.env.NEXT_PUBLIC_IMAGE_URL || "";
     const postImages = [
       post.screenshot1,
       post.screenshot2,
       post.screenshot3,
       post.screenshot4,
-    ].filter((img) => img !== null) as string[];
+    ]
+      .filter((img): img is string => img !== null)
+      .map((img) => `${imageUrlBase}/assets/uploads/userreviews/${img}`);
+
+    const authorImage = post.user.profile_picture
+      ? `${imageUrlBase}${post.user.profile_picture}`
+      : "/images/campaign-details/posts/author1.png";
 
     return {
-      authorImage: "/images/campaign-details/posts/author1.png", // Mock data, as it's not in the response
+      authorImage: authorImage,
       authorName: post.user.name,
       instagramUsername: post.user.instagram_url || "N/A",
       stats: {

--- a/src/types/entities/campaign.ts
+++ b/src/types/entities/campaign.ts
@@ -272,6 +272,7 @@ export interface CampaignReviewPostUser {
   name: string;
   instagram_url: string | null;
   instagram_followers: number | null;
+  profile_picture: string | null;
 }
 
 export interface CampaignReviewPost {


### PR DESCRIPTION
This commit introduces the functionality to display campaign review posts in the campaign details page, and ensures that all image URLs are correctly constructed.

- Adds Redux state, actions, and a saga to fetch campaign review posts from the `/api/campaign/review-posts/{id}` endpoint.
- Updates the "Posts" tab in the campaign details page to display the fetched posts, including user information, followers, reach, and images.
- Implements pagination for the review posts.
- Formats follower and reach numbers to be displayed in "K" format when over 1000.
- Corrects the API call to use the POST method and sends `per_page` in the payload.
- Constructs the full image URLs for post screenshots and author profile pictures using the `NEXT_PUBLIC_IMAGE_URL` environment variable.