### PR TITLE
feat: Implement campaign review posts with UI enhancements

### DIFF
--- a/src/components/features/campaigns/tabs/Posts/CampaignDetailsPost.tsx
+++ b/src/components/features/campaigns/tabs/Posts/CampaignDetailsPost.tsx
@@ -94,7 +94,7 @@ export default function CampaignDetailsPost({
           {imagesToShow.map((image, index) => (
             <div
               key={index}
-              className="flex-1 rounded-[13px] cursor-pointer relative"
+              className="w-[119px] h-[119px] rounded-[13px] cursor-pointer relative"
               onClick={() => openModal(index)}
             >
               <Image
@@ -102,11 +102,11 @@ export default function CampaignDetailsPost({
                 alt={`Post ${index + 1}`}
                 width={119}
                 height={119}
-                className="rounded-[13px] object-cover"
+                className="rounded-[13px] object-cover w-full h-full"
               />
               {index === 2 && remainingImagesCount > 0 && (
-                <div className="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center rounded-[13px]">
-                  <p className="text-white text-2xl font-bold">
+                <div className="absolute inset-0 bg-white/30 backdrop-blur-sm flex items-center justify-center rounded-[13px]">
+                  <p className="text-gray-800 text-2xl font-bold">
                     +{remainingImagesCount}
                   </p>
                 </div>


### PR DESCRIPTION
This commit introduces the functionality to display campaign review posts on the campaign details page, including all requested UI and data handling features.

- Adds Redux state, actions, and a saga to fetch campaign review posts from the `/api/campaign/review-posts/{id}` endpoint.
- Updates the "Posts" tab in the campaign details page to display the fetched posts, including user information, followers, reach, and images.
- Implements pagination for the review posts.
- Formats follower and reach numbers to be displayed in "K" format when over 1000.
- Corrects the API call to use the POST method and sends `per_page` in the payload.
- Constructs the full image URLs for post screenshots and author profile pictures using the `NEXT_PUBLIC_IMAGE_URL` environment variable.
- Fixes a runtime error by correcting the data structure passed to the Redux reducer.
- Adjusts the styling of post images to ensure consistent dimensions and a transparent overlay for the extra image count.