### PR TITLE
feat: Implement campaign review posts with full UI and data handling

### DIFF
--- a/src/components/features/campaigns/tabs/Posts.tsx
+++ b/src/components/features/campaigns/tabs/Posts.tsx
@@ -71,10 +71,10 @@ export default function Posts({ campaign }: PostsProps) {
 
     const authorImage = post.user.profile_picture
       ? `${imageUrlBase}${post.user.profile_picture}`
-      : "/images/campaign-details/posts/author1.png";
+      : null;
 
     return {
-      authorImage: authorImage,
+      authorImage,
       authorName: post.user.name,
       instagramUsername: post.user.instagram_url || "N/A",
       stats: {

--- a/src/components/features/campaigns/tabs/Posts/CampaignDetailsPost.tsx
+++ b/src/components/features/campaigns/tabs/Posts/CampaignDetailsPost.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import ImageSliderModal from "./ImageSliderModal";
 
 interface CampaignDetailsPostProps {
-  authorImage: string;
+  authorImage: string | null;
   authorName: string;
   instagramUsername: string;
   stats: {
@@ -13,6 +13,21 @@ interface CampaignDetailsPostProps {
   };
   postImages: string[];
 }
+
+const getInitials = (name: string): string => {
+  if (!name) return "";
+  const words = name.trim().split(" ").filter(Boolean);
+  if (words.length > 1 && words[1]) {
+    return `${words[0][0]}${words[1][0]}`.toUpperCase();
+  }
+  if (words[0]?.length > 1) {
+    return words[0].substring(0, 2).toUpperCase();
+  }
+  if (words[0]) {
+    return words[0][0].toUpperCase();
+  }
+  return "";
+};
 
 export default function CampaignDetailsPost({
   authorImage,
@@ -39,14 +54,20 @@ export default function CampaignDetailsPost({
   return (
     <>
       <article className="max-w-[412px] rounded-[13px] md:shadow-[0_0_4px_rgba(0,0,0,0.16)] p-4">
-        <div className="w-[72.64px] h-[72.64px] rounded-full overflow-hidden mx-auto">
-          <Image
-            src={authorImage}
-            alt={authorName}
-            width={72.64}
-            height={72.64}
-            className="rounded-full object-cover"
-          />
+        <div className="w-[72.64px] h-[72.64px] rounded-full overflow-hidden mx-auto flex items-center justify-center bg-gray-200">
+          {authorImage ? (
+            <Image
+              src={authorImage}
+              alt={authorName}
+              width={72.64}
+              height={72.64}
+              className="object-cover w-full h-full"
+            />
+          ) : (
+            <span className="text-2xl font-bold text-gray-600">
+              {getInitials(authorName)}
+            </span>
+          )}
         </div>
         <div className="mt-[7.7px] text-center">
           <h3 className="text-[15px] font-medium text-[#4F4F4F] leading-[23px]">


### PR DESCRIPTION
This commit introduces the functionality to display campaign review posts on the campaign details page, including all requested UI and data handling features.

- Adds Redux state, actions, and a saga to fetch campaign review posts from the `/api/campaign/review-posts/{id}` endpoint.
- Updates the "Posts" tab in the campaign details page to display the fetched posts.
- Implements pagination for the review posts.
- Formats follower and reach numbers to be displayed in "K" format when over 1000.
- Corrects the API call to use the POST method and sends `per_page` in the payload.
- Constructs the full image URLs for post screenshots and author profile pictures using the `NEXT_PUBLIC_IMAGE_URL` environment variable.
- Implements a fallback to display the user's initials if a profile picture is not available.
- Fixes a runtime error by correcting the data structure passed to the Redux reducer.
- Adjusts the styling of post images to ensure consistent dimensions and a transparent overlay for the extra image count.