### PR TITLE
feat: Implement campaign review posts with all UI and data handling

### DIFF
--- a/src/components/features/campaigns/tabs/Posts/CampaignDetailsPost.tsx
+++ b/src/components/features/campaigns/tabs/Posts/CampaignDetailsPost.tsx
@@ -101,7 +101,7 @@ export default function CampaignDetailsPost({
             </p>
             <p className="text-[9px] leading-[13px] text-[#4F4F4F]">Reach</p>
           </div>
-          <div className="w-[1px] h-[18.65px] bg-[#00A4B6]"></div>
+          {/* <div className="w-[1px] h-[18.65px] bg-[#00A4B6]"></div>
           <div className="flex-1 text-center">
             <p className="text-[15px] font-medium text-[#00A4B6] leading-[22px]">
               {stats.engagement}
@@ -109,7 +109,7 @@ export default function CampaignDetailsPost({
             <p className="text-[9px] leading-[13px] text-[#4F4F4F]">
               Engagement
             </p>
-          </div>
+          </div> */}
         </div>
         <div className="flex items-center justify-center gap-3">
           {imagesToShow.map((image, index) => (


### PR DESCRIPTION
This commit introduces the functionality to display campaign review posts on the campaign details page, including all requested UI and data handling features.

- Adds Redux state, actions, and a saga to fetch campaign review posts from the `/api/campaign/review-posts/{id}` endpoint.
- Updates the "Posts" tab in the campaign details page to display the fetched posts.
- Implements pagination for the review posts.
- Formats follower and reach numbers to be displayed in "K" format when over 1000.
- Corrects the API call to use the POST method and sends `per_page` in the payload.
- Constructs the full image URLs for post screenshots and author profile pictures using the `NEXT_PUBLIC_IMAGE_URL` environment variable.
- Implements a fallback to display the user's initials if a profile picture is not available.
- Fixes a runtime error by correcting the data structure passed to the Redux reducer.
- Adjusts the styling of post images to ensure consistent dimensions and a transparent overlay for the extra image count.
- Comments out the engagement section in the post card as requested.