### PR TITLE
Fix: Correct dashboard loading and rendering issues

### DIFF
--- a/src/app/(features)/dashboard/page.tsx
+++ b/src/app/(features)/dashboard/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import Image from "next/image";
 import BarChart from "@/components/charts/BarChart";
 import DonutChart from "@/components/charts/RingChart";
 import LineChart from "@/components/charts/LineChart";
@@ -74,16 +75,27 @@ export default function Dashboard() {
                 <p>Completed campaigns</p>
               </div>
             </div>
-            <BarChart
-              data={weeklyData}
-              xAxisKey="day"
-              barKeys={["active", "completed"]}
-              maxBarWidth={20.67}
-              showYTicks={false}
-              yAxisValues={["0", "2", "4", "6", "8", "10", "12"]} // 8 elements
-              showGridLines={true} // Show default dotted grid lines
-              heightPx={280}
-            />
+            {dashboardData?.campaignPerformance ? (
+              <BarChart
+                data={weeklyData}
+                xAxisKey="day"
+                barKeys={["active", "completed"]}
+                maxBarWidth={20.67}
+                showYTicks={false}
+                yAxisValues={["0", "2", "4", "6", "8", "10", "12"]} // 8 elements
+                showGridLines={true} // Show default dotted grid lines
+                heightPx={280}
+              />
+            ) : (
+              <div className="flex justify-center items-center h-[280px]">
+                <img
+                  src="/icons/loader.gif"
+                  alt="Loading..."
+                  width={50}
+                  height={50}
+                />
+              </div>
+            )}
           </div>
 
           {/* <div className="p-1 md:p-7 bg-white rounded-[13px] text-[#4F4F4F] text-[11px] flex-1">

--- a/src/components/features/dashboard/DashboardStatCards.tsx
+++ b/src/components/features/dashboard/DashboardStatCards.tsx
@@ -4,7 +4,6 @@ import {
   selectDashboardData,
   selectDashboardLoading,
 } from "@/store/dashboard/dashboardSlice";
-import Loader from "@/components/general/Loader";
 
 const statCardIcons = {
   campaignsCount: {
@@ -37,22 +36,29 @@ export default function DashboardStatCards() {
   const dashboardData = useSelector(selectDashboardData);
   const loading = useSelector(selectDashboardLoading);
 
-  if (loading) {
-    return (
-      <div className="flex justify-center items-center h-24">
-        <Image src="/icons/loader.gif" alt="Loading..." width={50} height={50} />
-      </div>
-    );
-  }
-
-  const statCards = dashboardData
-    ? [
-        { ...statCardIcons.campaignsCount, value: dashboardData.campaignsCount },
-        { ...statCardIcons.influencersCount, value: dashboardData.influencersCount },
-        { ...statCardIcons.brandsCount, value: dashboardData.brandsCount },
-        { ...statCardIcons.pendingCount, value: dashboardData.pendingCount },
-      ]
-    : [];
+  const statCards =
+    !loading && dashboardData
+      ? [
+          {
+            ...statCardIcons.campaignsCount,
+            value: dashboardData.campaignsCount,
+          },
+          {
+            ...statCardIcons.influencersCount,
+            value: dashboardData.influencersCount,
+          },
+          { ...statCardIcons.brandsCount, value: dashboardData.brandsCount },
+          {
+            ...statCardIcons.pendingCount,
+            value: dashboardData.pendingCount,
+          },
+        ]
+      : [
+          statCardIcons.campaignsCount,
+          statCardIcons.influencersCount,
+          statCardIcons.brandsCount,
+          statCardIcons.pendingCount,
+        ];
 
   return (
     <div className="flex gap-[21px] justify-between">
@@ -73,9 +79,20 @@ export default function DashboardStatCards() {
             <p className="text-[18px] leading-[27px] font-semibold text-[#4F4F4F]">
               {card.title}
             </p>
-            <p className="text-[24px] font-medium text-[#00A4B6] leading-[35px]">
-              {card.value}
-            </p>
+            {loading ? (
+              <div className="mt-2">
+                <img
+                  src="/icons/loader.gif"
+                  alt="Loading..."
+                  width={35}
+                  height={35}
+                />
+              </div>
+            ) : (
+              <p className="text-[24px] font-medium text-[#00A4B6] leading-[35px]">
+                {(card as any).value}
+              </p>
+            )}
           </div>
         </article>
       ))}


### PR DESCRIPTION
This commit addresses two issues on the dashboard:
1.  The "Campaign Performance" bar chart now displays a loading indicator while data is being fetched, preventing rendering errors with empty data.
2.  The dashboard statistics cards are now visible on page load, with loading indicators for the numerical values, which are populated once the data is available.

These changes improve the user experience by providing immediate feedback and preventing layout shifts during data loading.