### PR TITLE
feat: Address final user feedback on campaign details page

### DIFF
--- a/src/app/(features)/businesses/campaigns/[campaignId]/page.tsx
+++ b/src/app/(features)/businesses/campaigns/[campaignId]/page.tsx
@@ -46,14 +46,12 @@ export default function CampaignDetailsPage() {
     setActiveTab(tab);
   };
 
-  const loading = campaignLoading || (activeTab === "Business Details" && brandLoading);
-  if (loading) {
+  if (campaignLoading) {
     return <Loader />;
   }
 
-  const error = campaignError || (activeTab === "Business Details" && brandError);
-  if (error) {
-    return <p className="text-red-500">Error: {error}</p>;
+  if (campaignError) {
+    return <p className="text-red-500">Error: {campaignError}</p>;
   }
 
   if (!campaign) {
@@ -74,15 +72,21 @@ export default function CampaignDetailsPage() {
         {activeTab === "Campaigns" && (
           <CampaignDetails campaign={campaign} campaignId={campaignId as string} />
         )}
-        {activeTab === "Business Details" && brand && (
-          <BrandDetails
-            brand={brand}
-            isEditMode={false}
-            onFieldChange={() => {}}
-            onSave={() => {}}
-            isSaving={false}
-            isCreateMode={false}
-          />
+        {activeTab === "Business Details" && (
+          <>
+            {brandLoading && <Loader />}
+            {brandError && <p className="text-red-500 text-center py-8">{brandError}</p>}
+            {!brandLoading && !brandError && brand && (
+              <BrandDetails
+                brand={brand}
+                isEditMode={false}
+                onFieldChange={() => {}}
+                onSave={() => {}}
+                isSaving={false}
+                isCreateMode={false}
+              />
+            )}
+          </>
         )}
       </div>
     </div>


### PR DESCRIPTION
This commit addresses the final round of user feedback on the campaign details page:

1.  **Business Details Tab:** The "Business Details" tab on the campaign details page now correctly displays the brand information in a read-only mode. The loading indicator is now displayed within the tab's content area, ensuring the header and tabs remain visible while the brand details are being fetched.