### PR TITLE
feat: Address final user feedback on campaign details page

### DIFF
--- a/src/app/(features)/businesses/campaigns/[campaignId]/page.tsx
+++ b/src/app/(features)/businesses/campaigns/[campaignId]/page.tsx
@@ -1,34 +1,23 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { getCampaignDetailsStart } from "@/store/campaigns/CampaignSlice";
-import { fetchBrandRequest } from "@/store/brand/brandSlice";
 import { RootState } from "@/store/store";
 import Loader from "@/components/general/Loader";
 import CampaignDetails from "@/components/features/campaigns/CampaignDetails";
-import BrandDetails from "@/components/features/brands/BrandDetails";
-import BrandHeader from "@/components/features/brands/BrandHeader";
+import Image from "next/image";
 
 export default function CampaignDetailsPage() {
   const dispatch = useDispatch();
   const params = useParams();
+  const router = useRouter();
   const { campaignId } = params;
 
-  const [activeTab, setActiveTab] = useState("Campaigns");
-
-  const {
-    campaign,
-    loading: campaignLoading,
-    error: campaignError,
-  } = useSelector((state: RootState) => state.campaigns);
-
-  const {
-    brand,
-    loading: brandLoading,
-    error: brandError,
-  } = useSelector((state: RootState) => state.brand);
+  const { campaign, loading, error } = useSelector(
+    (state: RootState) => state.campaigns
+  );
 
   useEffect(() => {
     if (campaignId) {
@@ -36,22 +25,16 @@ export default function CampaignDetailsPage() {
     }
   }, [dispatch, campaignId]);
 
-  useEffect(() => {
-    if (campaign && activeTab === "Business Details" && campaign.venue) {
-      dispatch(fetchBrandRequest({ brandId: campaign.venue.id }));
-    }
-  }, [dispatch, campaign, activeTab]);
-
-  const handleTabChange = (tab: string) => {
-    setActiveTab(tab);
+  const handleBackClick = () => {
+    router.push(`/businesses/campaigns`);
   };
 
-  if (campaignLoading) {
+  if (loading) {
     return <Loader />;
   }
 
-  if (campaignError) {
-    return <p className="text-red-500">Error: {campaignError}</p>;
+  if (error) {
+    return <p className="text-red-500">Error: {error}</p>;
   }
 
   if (!campaign) {
@@ -59,35 +42,31 @@ export default function CampaignDetailsPage() {
   }
 
   return (
-    <div className="pt-6">
-      <BrandHeader
-        name={campaign.venue?.venue_title || campaign.brandName}
-        subtitle={campaign.title}
-        logo={campaign.brandLogo}
-        tabs={["Business Details", "Campaigns"]}
-        activeTab={activeTab}
-        onTabChange={handleTabChange}
-      />
-      <div className="pb-6">
-        {activeTab === "Campaigns" && (
-          <CampaignDetails campaign={campaign} campaignId={campaignId as string} />
-        )}
-        {activeTab === "Business Details" && (
-          <>
-            {brandLoading && <Loader />}
-            {brandError && <p className="text-red-500 text-center py-8">{brandError}</p>}
-            {!brandLoading && !brandError && brand && (
-              <BrandDetails
-                brand={brand}
-                isEditMode={false}
-                onFieldChange={() => {}}
-                onSave={() => {}}
-                isSaving={false}
-                isCreateMode={false}
-              />
-            )}
-          </>
-        )}
+    <div className="py-6">
+      <div className="max-w-[1428px] mx-auto bg-white rounded-[13px]">
+        <div className="flex items-center justify-between py-[20.5px] px-[27px] border-b border-[#E2E2E2]">
+          <button onClick={handleBackClick} className="cursor-pointer">
+            <Image
+              src="/icons/campaign/details/back-arrow.svg"
+              alt="back"
+              width={35}
+              height={35}
+            />
+          </button>
+          <h4 className="text-[18px] leading-[27px] font-semibold text-[#4F4F4F]">
+            {campaign.title}
+          </h4>
+          <button className="cursor-pointer">
+            <Image
+              src="/icons/campaign/details/menu-dots.svg"
+              alt="share"
+              width={35}
+              height={35}
+            />
+          </button>
+        </div>
+
+        <CampaignDetails campaign={campaign} campaignId={campaignId as string} />
       </div>
     </div>
   );

--- a/src/components/features/campaigns/CampaignDetails.tsx
+++ b/src/components/features/campaigns/CampaignDetails.tsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Campaign } from "@/types/entities";
 import { RootState } from "@/store/store";
 import { updateCampaignStatusStart } from "@/store/campaigns/CampaignSlice";
+import { fetchBrandRequest } from "@/store/brand/brandSlice";
 import RejectReasonModal from "./RejectReasonModal";
 import Overview from "./tabs/Overview";
 import Creators from "./tabs/Creators";
@@ -14,6 +15,8 @@ import Availabilites from "./tabs/Availabilites";
 import Posts from "./tabs/Posts";
 import VoucherCode from "./tabs/VoucherCode";
 import Reviews from "./tabs/Reviews";
+import BrandDetails from "../brands/BrandDetails";
+import Loader from "@/components/general/Loader";
 
 const tabs = [
   "Creators",
@@ -22,6 +25,7 @@ const tabs = [
   "Voucher Code",
   "Posts",
   "Reviews",
+  "Business Details",
 ];
 
 export default function CampaignDetails({
@@ -37,7 +41,9 @@ export default function CampaignDetails({
   const { statusUpdateLoading } = useSelector(
     (state: RootState) => state.campaigns
   );
-
+  const { brand, loading: brandLoading } = useSelector(
+    (state: RootState) => state.brand
+  );
   const [selectedIndex, setSelectedIndex] = useState(1); // Default to Overview (index 1)
   const [isRejectModalOpen, setIsRejectModalOpen] = useState(false);
 
@@ -48,6 +54,13 @@ export default function CampaignDetails({
     }
     return 1; // Default to Overview
   }, [searchParams]);
+
+  useEffect(() => {
+    const currentTab = tabs[selectedIndex];
+    if (currentTab === "Business Details" && campaign.venue?.id) {
+      dispatch(fetchBrandRequest({ brandId: campaign.venue.id }));
+    }
+  }, [selectedIndex, dispatch, campaign.venue?.id]);
 
   const handleApprove = () => {
     dispatch(updateCampaignStatusStart({ id: campaignId, status: "Approved" }));
@@ -132,6 +145,21 @@ export default function CampaignDetails({
               {tab === "Posts" && <Posts />}
               {tab === "Reviews" && <Reviews campaignId={campaignId} />}
               {tab === "Voucher Code" && <VoucherCode />}
+              {tab === "Business Details" &&
+                (brandLoading ? (
+                  <Loader />
+                ) : brand ? (
+                  <BrandDetails
+                    brand={brand}
+                    isEditMode={false}
+                    onFieldChange={() => {}}
+                    onSave={() => {}}
+                    isSaving={false}
+                    isCreateMode={false}
+                  />
+                ) : (
+                  <p>Brand details not available.</p>
+                ))}
             </TabPanel>
           ))}
         </TabPanels>


### PR DESCRIPTION
This commit addresses the final round of user feedback on the campaign details page:

1.  **Business Details Tab:** The "Business Details" tab has been added to the campaign details page. It correctly displays the brand information in a read-only mode, with all form fields, including dropdowns and file uploads, disabled. The download buttons for existing files remain functional.
2.  **Header and UI:** The campaign details page now retains its original UI, including the header and back button, ensuring a consistent user experience. The loading indicator for the brand details is now displayed within the "Business Details" tab's content area, so the main header and tabs remain visible while the brand information is being fetched.