### PR TITLE
feat: Implement Change Phone Number feature with OTP verification

### DIFF
--- a/src/store/account/accountSlice.ts
+++ b/src/store/account/accountSlice.ts
@@ -197,10 +197,11 @@ const accountSlice = createSlice({
     clearAccountError(state) {
       state.error = null;
     },
-    sendOtpRequest(state, _action: PayloadAction<{ phone: string; country_code: string, accountId: string }>) {
+    sendOtpRequest(state, _action: PayloadAction<{ phone: string; country_code: string }>) {
       state.phoneUpdateInProgress = true;
       state.phoneUpdateError = null;
       state.otpSent = false;
+      state.otpVerified = false; // Reset verification status on new OTP request
     },
     sendOtpSuccess(state) {
       state.phoneUpdateInProgress = false;
@@ -210,7 +211,7 @@ const accountSlice = createSlice({
       state.phoneUpdateInProgress = false;
       state.phoneUpdateError = action.payload;
     },
-    verifyOtpRequest(state, _action: PayloadAction<{ phone: string; country_code: string; otp: string, accountId: string }>) {
+    verifyOtpRequest(state, _action: PayloadAction<{ phone: string; country_code: string; otp: string }>) {
       state.phoneUpdateInProgress = true;
       state.phoneUpdateError = null;
       state.otpVerified = false;


### PR DESCRIPTION
This commit introduces the "Change Phone Number" feature, which allows users to update their phone number through a two-step OTP verification process.

Key changes include:
- A new "Change Phone Number" tab is added to the user's profile page.
- The phone number field is now hidden on the main details tab when a user is viewing their own profile.
- The "Brands" tab is now hidden for admin users viewing their own profile.
- Redux actions and sagas have been added to handle the OTP send and verify API calls.
- A new `ChangePhoneNumber` component has been created to encapsulate the OTP flow.
- The OTP verification state is now correctly reset, allowing for multiple phone number changes without a page refresh.
- Temporarily commented out corrupted image assets in `BrandsData.ts` to allow the project to build.